### PR TITLE
Initial ci

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -56,6 +56,14 @@ fmt:
   stage:                           check
   script:
     - cargo fmt -- --check
+  allow_failure:                   true
+
+clippy:
+  <<:                              *docker-env
+  stage:                           check
+  script:
+    - cargo clippy --all-targets
+  allow_failure:                   true
 
 #### stage:                       test
 

--- a/.gitlab.ci.yml
+++ b/.gitlab.ci.yml
@@ -66,7 +66,7 @@ nightly-test:
     EXTRA_FEATURES:                "$EXTRA_FEATURES unstable"
   script:
     - cargo build --verbose --features="all ${EXTRA_FEATURES}" || exit 1
-    - RUST_BACKTRACE=1 cargo test --workspace --verbose --no-default-features --features="${EXTRA_FEATURES}" 
+    - RUST_BACKTRACE=1 cargo test --workspace --verbose --no-default-features --features="${EXTRA_FEATURES}"
     - RUST_BACKTRACE=1 cargo test --workspace --verbose --features="all ${EXTRA_FEATURES}"
 
 stable-test:
@@ -77,6 +77,6 @@ stable-test:
     - mkdir -p ./artifacts/sccache/
   script:
     - cargo +stable build --verbose --all-features
-    - RUST_BACKTRACE=1 cargo +stable test --workspace --verbose --no-default-features --features="${EXTRA_FEATURES}" 
+    - RUST_BACKTRACE=1 cargo +stable test --workspace --verbose --no-default-features --features="${EXTRA_FEATURES}"
     - RUST_BACKTRACE=1 cargo +stable test --workspace --verbose --all-features
     - mv ./target/release/sccache ./artifacts/sccache/.

--- a/.gitlab.ci.yml
+++ b/.gitlab.ci.yml
@@ -1,0 +1,82 @@
+# .gitlab-ci.yml
+#
+# sccache
+
+
+stages:
+  - check
+  - test
+  - deploy
+
+variables:
+  GIT_STRATEGY:                    fetch
+  GIT_DEPTH:                       100
+  CARGO_INCREMENTAL:               0
+
+workflow:
+  rules:
+    - if: $CI_COMMIT_TAG
+    - if: $CI_COMMIT_BRANCH
+
+.docker-env:                       &docker-env
+  image:                           paritytech/ink-ci-linux:latest
+  before_script:
+    - rustup show
+    - cargo --version
+    - sccache -s
+  retry:
+    max: 2
+    when:
+      - runner_system_failure
+      - unknown_failure
+      - api_failure
+  interruptible:                   true
+  tags:
+    - linux-docker
+  rules:
+    - if: $CI_PIPELINE_SOURCE == "web"
+    - if: $CI_PIPELINE_SOURCE == "schedule"
+    - if: $CI_COMMIT_REF_NAME == "master"
+    - if: $CI_COMMIT_REF_NAME == "tags"
+    - if: $CI_COMMIT_REF_NAME =~ /^[0-9]+$/                         # PRs
+    - if: $CI_COMMIT_REF_NAME =~ /^v[0-9]+\.[0-9]+.*$/              # i.e. v1.0, v2.1rc1
+
+.collect-artifacts:                &collect-artifacts
+  artifacts:
+    name:                          "${CI_JOB_NAME}_${CI_COMMIT_REF_NAME}"
+    when:                          on_success
+    expire_in:                     7 days
+    paths:
+      - artifacts/
+
+#### stage:                       check
+
+fmt:
+  <<:                              *docker-env
+  stage:                           check
+  script:
+    - cargo fmt -- --check
+
+#### stage:                       test
+
+nightly-test:
+  <<:                              *docker-env
+  stage:                           test
+  variables:
+    EXTRA_FEATURES:                "$EXTRA_FEATURES unstable"
+  script:
+    - cargo build --verbose --features="all ${EXTRA_FEATURES}" || exit 1
+    - RUST_BACKTRACE=1 cargo test --workspace --verbose --no-default-features --features="${EXTRA_FEATURES}" 
+    - RUST_BACKTRACE=1 cargo test --workspace --verbose --features="all ${EXTRA_FEATURES}"
+
+stable-test:
+  stage:                           test
+  <<:                              *docker-env
+  <<:                              *collect-artifacts
+  before_script:
+    - mkdir -p ./artifacts/sccache/
+  script:
+    - cargo +stable build --verbose --all-features
+    - RUST_BACKTRACE=1 cargo +stable test --workspace --verbose --no-default-features --features="${EXTRA_FEATURES}" 
+    - RUST_BACKTRACE=1 cargo +stable test --workspace --verbose --all-features
+    - mv ./target/release/sccache ./artifacts/sccache/.


### PR DESCRIPTION
The [image](https://github.com/paritytech/scripts/blob/c106e839cace9ca5837fd4895bc3af03251c9d42/dockerfiles/ink-ci-linux/Dockerfile) is temporary. Rust there is updated according to the [latest](https://rust-lang.github.io/rustup-components-history/) known to support the listed components. Default is nightly.
 
Not sure if we need separate jobs for stable and nightly versions of Rust, just copied how it was on the upstream.

With the deployment I guess, it makes sense to wait until #7 gets merged.