### PR TITLE
Add the ability to clear a cache.

### DIFF
--- a/src/cache/azure.rs
+++ b/src/cache/azure.rs
@@ -90,7 +90,13 @@ impl Storage for AzureBlobCache {
     fn current_size(&self) -> SFuture<Option<u64>> {
         f_ok(None)
     }
+
     fn max_size(&self) -> SFuture<Option<u64>> {
         f_ok(None)
+    }
+
+    fn clear(&self) -> SFuture<()> {
+        trace!("AzureBlobCache::clear - NOT IMPLEMENTED");
+        f_err(anyhow!("AzureBlobCache::clear is not implemented"))
     }
 }

--- a/src/cache/cache.rs
+++ b/src/cache/cache.rs
@@ -282,6 +282,9 @@ pub trait Storage {
 
     /// Get the maximum storage size, if applicable.
     fn max_size(&self) -> SFuture<Option<u64>>;
+
+    /// Clear the contents of the cache.
+    fn clear(&self) -> SFuture<()>;
 }
 
 /// Get a suitable `Storage` implementation from configuration.

--- a/src/cache/disk.rs
+++ b/src/cache/disk.rs
@@ -100,4 +100,10 @@ impl Storage for DiskCache {
     fn max_size(&self) -> SFuture<Option<u64>> {
         f_ok(Some(self.lru.lock().unwrap().capacity()))
     }
+
+    fn clear(&self) -> SFuture<()> {
+        trace!("DiskCache::clear");
+        let lru = self.lru.clone();
+        Box::new(self.pool.spawn_fn(move || Ok(lru.lock().unwrap().clear()?)))
+    }
 }

--- a/src/cache/gcs.rs
+++ b/src/cache/gcs.rs
@@ -542,8 +542,14 @@ impl Storage for GCSCache {
     fn current_size(&self) -> SFuture<Option<u64>> {
         Box::new(future::ok(None))
     }
+
     fn max_size(&self) -> SFuture<Option<u64>> {
         Box::new(future::ok(None))
+    }
+
+    fn clear(&self) -> SFuture<()> {
+        trace!("GCSCache::clear - NOT IMPLEMENTED");
+        Box::new(future::err(anyhow!("GCSCache::clear is not implemented")))
     }
 }
 

--- a/src/cache/memcached.rs
+++ b/src/cache/memcached.rs
@@ -95,7 +95,13 @@ impl Storage for MemcachedCache {
     fn current_size(&self) -> SFuture<Option<u64>> {
         f_ok(None)
     }
+
     fn max_size(&self) -> SFuture<Option<u64>> {
         f_ok(None)
+    }
+
+    fn clear(&self) -> SFuture<()> {
+        trace!("MemcachedCache::clear - NOT IMPLEMENTED");
+        f_err(anyhow!("MemcachedCache::clear is not implemented"))
     }
 }

--- a/src/cache/redis.rs
+++ b/src/cache/redis.rs
@@ -117,4 +117,9 @@ impl Storage for RedisCache {
             .compat(),
         )
     }
+
+    fn clear(&self) -> SFuture<()> {
+        trace!("RedisCache::clear - NOT IMPLEMENTED");
+        f_err(anyhow!("RedisCache::clear is not implemented"))
+    }
 }

--- a/src/cache/s3.rs
+++ b/src/cache/s3.rs
@@ -130,7 +130,13 @@ impl Storage for S3Cache {
     fn current_size(&self) -> SFuture<Option<u64>> {
         Box::new(future::ok(None))
     }
+
     fn max_size(&self) -> SFuture<Option<u64>> {
         Box::new(future::ok(None))
+    }
+
+    fn clear(&self) -> SFuture<()> {
+        trace!("S3Cache::clear - NOT IMPLEMENTED");
+        Box::new(future::err(anyhow!("S3Cache::clear is not implemented")))
     }
 }

--- a/src/cmdline.rs
+++ b/src/cmdline.rs
@@ -57,6 +57,8 @@ pub enum Command {
         /// The environment variables to use for execution.
         env_vars: Vec<(OsString, OsString)>,
     },
+    /// Clear the cache of entries.
+    ClearCache,
 }
 
 /// Get the `App` used for argument parsing.
@@ -78,7 +80,8 @@ pub fn get_app<'a, 'b>() -> App<'a, 'b> {
              --stop-server    'stop background server'
              -z, --zero-stats 'zero statistics counters'
              --dist-auth      'authenticate for distributed compilation'
-             --dist-status    'show status of the distributed client'"
+             --dist-status    'show status of the distributed client'
+             --clear-cache    'clear the contents of the on-disk cache'"
                 )
         .arg(Arg::from_usage("--package-toolchain <executable> <out> 'package toolchain for distributed compilation'")
              .required(false))
@@ -151,6 +154,7 @@ pub fn parse() -> Result<Command> {
     let dist_status = matches.is_present("dist-status");
     let package_toolchain = matches.is_present("package-toolchain");
     let cmd = matches.values_of_os("cmd");
+    let clear_cache = matches.is_present("clear-cache");
     // Ensure that we've only received one command to run.
     fn is_some<T>(x: &Option<T>) -> bool {
         x.is_some()
@@ -187,6 +191,8 @@ pub fn parse() -> Result<Command> {
         Ok(Command::DistAuth)
     } else if dist_status {
         Ok(Command::DistStatus)
+    } else if clear_cache {
+        Ok(Command::ClearCache)
     } else if package_toolchain {
         let mut values = matches
             .values_of_os("package-toolchain")

--- a/src/commands.rs
+++ b/src/commands.rs
@@ -376,6 +376,13 @@ where
     }
 }
 
+pub fn request_clear_cache(mut conn: ServerConnection) -> Result<()> {
+    debug!("clear_cache");
+    conn.request(Request::ClearCache)
+        .context("Failed to send data to or receive data from server")?;
+    Ok(())
+}
+
 /// Return the signal that caused a process to exit from `status`.
 #[cfg(unix)]
 #[allow(dead_code)]
@@ -713,6 +720,11 @@ pub fn run_command(cmd: Command) -> Result<i32> {
                 &mut io::stderr(),
             );
             return res.context("failed to execute compile");
+        }
+        Command::ClearCache => {
+            trace!("Command::ClearCache");
+            let conn = connect_or_start_server(get_port())?;
+            request_clear_cache(conn).context("couldn't clear cache on server")?;
         }
     }
 

--- a/src/protocol.rs
+++ b/src/protocol.rs
@@ -15,6 +15,7 @@ pub enum Request {
     Shutdown,
     /// Execute a compile or fetch a cached compilation result.
     Compile(Compile),
+    ClearCache,
 }
 
 /// A server response.
@@ -30,6 +31,8 @@ pub enum Response {
     ShuttingDown(Box<ServerInfo>),
     /// Second response for `Request::Compile`, containing the results of the compilation.
     CompileFinished(CompileFinished),
+    /// Response for Request::ClearCache.
+    ClearCacheComplete,
 }
 
 /// Possible responses from the server for a `Compile` request.

--- a/src/server.rs
+++ b/src/server.rs
@@ -722,6 +722,10 @@ where
                     Message::WithoutBody(Response::ShuttingDown(Box::new(info)))
                 }));
             }
+            Request::ClearCache => {
+                debug!("handle_client: clear_cache");
+                Box::new(self.clear_cache().map(|_| Response::ClearCacheComplete))
+            }
         };
 
         Box::new(res.map(Message::WithoutBody))
@@ -827,6 +831,10 @@ where
     /// Zero stats about the cache.
     fn zero_stats(&self) {
         *self.stats.borrow_mut() = ServerStats::default();
+    }
+
+    fn clear_cache(&self) -> SFuture<()> {
+        self.storage.clear()
     }
 
     /// Handle a compile request from a client.

--- a/src/test/mock_storage.rs
+++ b/src/test/mock_storage.rs
@@ -58,4 +58,8 @@ impl Storage for MockStorage {
     fn max_size(&self) -> SFuture<Option<u64>> {
         Box::new(future::ok(None))
     }
+    fn clear(&self) -> SFuture<()> {
+        self.gets.borrow_mut().clear();
+        Box::new(future::ok(()))
+    }
 }


### PR DESCRIPTION
This adds the --clear-cache argument that will remove the contents of
the cache.

This is implemented as `clear()` on the `Storage` trait - however it
is only implemented for the `DiskCache` (and `LruDiskCache`)
implementations. Any invocation on the other implementations will
return an `Err`.

A test for the `LruDiskCache` has also been included in this commit.