### PR TITLE
removing warnings and compiler errors

### DIFF
--- a/src/azure/blobstore.rs
+++ b/src/azure/blobstore.rs
@@ -16,7 +16,6 @@
 
 use crate::azure::credentials::*;
 use bytes::Buf;
-use futures_03::{Future, Stream};
 use hmac::{Hmac, Mac, NewMac};
 use hyperx::header;
 use md5::{Digest, Md5};

--- a/src/azure/blobstore.rs
+++ b/src/azure/blobstore.rs
@@ -20,7 +20,7 @@ use hmac::{Hmac, Mac, NewMac};
 use hyperx::header;
 use md5::{Digest, Md5};
 use reqwest::Url;
-use reqwest::{header::HeaderValue, Client, Method, Request, Response};
+use reqwest::{header::HeaderValue, Client, Method, Request};
 use sha2::Sha256;
 use std::fmt;
 use std::str::FromStr;

--- a/src/bin/sccache-dist/token_check.rs
+++ b/src/bin/sccache-dist/token_check.rs
@@ -147,7 +147,7 @@ impl MozillaCheck {
         let header = hyperx::header::Authorization(hyperx::header::Bearer {
             token: token.to_owned(),
         });
-        let mut res = self
+        let res = self
             .client
             .get(url.clone())
             .set_header(header)
@@ -329,7 +329,7 @@ impl ClientAuthCheck for ValidJWTCheck {
 
 impl ValidJWTCheck {
     pub fn new(audience: String, issuer: String, jwks_url: &str) -> Result<Self> {
-        let mut res =
+        let res =
             reqwest::blocking::get(jwks_url).context("Failed to make request to JWKs url")?;
         if !res.status().is_success() {
             bail!("Could not retrieve JWKs, HTTP error: {}", res.status())

--- a/src/cache/gcs.rs
+++ b/src/cache/gcs.rs
@@ -113,13 +113,13 @@ impl Bucket {
         let res = client
             .execute(request)
             .await
-            .map_err(|e| Error::from(format!("failed GET: {}", url)))?;
+            .map_err(|_e| Error::from(format!("failed GET: {}", url)))?;
         let status = res.status();
         if status.is_success() {
             let bytes = res
                 .bytes()
                 .await
-                .map_err(|e| Error::from("failed to read HTTP body"))?;
+                .map_err(|_e| Error::from("failed to read HTTP body"))?;
             Ok(bytes.iter().copied().collect())
         } else {
             Err(BadHttpStatusError(status).into())
@@ -425,7 +425,7 @@ impl GCSCredentialProvider {
             let token_msg = res
                 .json::<TokenMsg>()
                 .await
-                .map_err(|e| "failed to read HTTP body")?;
+                .map_err(|_e| "failed to read HTTP body")?;
             Ok(token_msg)
         } else {
             Err(Error::from(BadHttpStatusError(res_status)))
@@ -453,7 +453,7 @@ impl GCSCredentialProvider {
                 expiration_time: resp
                     .expire_time
                     .parse()
-                    .map_err(|e| "Failed to parse GCS expiration time")?,
+                    .map_err(|_e| "Failed to parse GCS expiration time")?,
             })
         } else {
             Err(Error::from(BadHttpStatusError(res.status())))
@@ -572,7 +572,7 @@ impl Storage for GCSCache {
         let data = entry.finish()?;
 
         let bucket = self.bucket.clone();
-        let response = bucket
+        let _response = bucket
             .put(&key, data, &self.credential_provider)
             .await
             .context("failed to put cache entry in GCS")?;

--- a/src/cache/gcs.rs
+++ b/src/cache/gcs.rs
@@ -577,10 +577,7 @@ impl Storage for GCSCache {
             .await
             .context("failed to put cache entry in GCS");
 
-        match(response) {
-            Ok(()) => Ok(start.elapsed()),
-            Err(e) => Err(e),
-        }
+        response.map(move |_| start.elapsed())
     }
 
     fn location(&self) -> String {

--- a/src/cache/gcs.rs
+++ b/src/cache/gcs.rs
@@ -572,12 +572,15 @@ impl Storage for GCSCache {
         let data = entry.finish()?;
 
         let bucket = self.bucket.clone();
-        let _response = bucket
+        let response = bucket
             .put(&key, data, &self.credential_provider)
             .await
-            .context("failed to put cache entry in GCS")?;
+            .context("failed to put cache entry in GCS");
 
-        Ok(start.elapsed())
+        match(response) {
+            Ok(()) => Ok(start.elapsed()),
+            Err(e) => Err(e),
+        }
     }
 
     fn location(&self) -> String {

--- a/src/cache/redis.rs
+++ b/src/cache/redis.rs
@@ -15,7 +15,6 @@
 
 use crate::cache::{Cache, CacheRead, CacheWrite, Storage};
 use crate::errors::*;
-use futures_03::prelude::*;
 use redis::aio::Connection;
 use redis::{cmd, Client, InfoDict};
 use std::collections::HashMap;

--- a/src/cache/s3.rs
+++ b/src/cache/s3.rs
@@ -22,7 +22,7 @@ use rusoto_core::{
     credential::{AutoRefreshingProvider, ChainProvider, ProfileProvider},
     Region,
 };
-use rusoto_s3::{Bucket, GetObjectOutput, GetObjectRequest, PutObjectRequest, S3Client, S3};
+use rusoto_s3::{GetObjectOutput, GetObjectRequest, PutObjectRequest, S3Client, S3};
 use std::io;
 use std::str::FromStr;
 use std::time::{Duration, Instant};
@@ -64,10 +64,6 @@ impl S3Cache {
         let provider =
             AutoRefreshingProvider::new(ChainProvider::with_profile_provider(profile_provider))?;
         let bucket_name = bucket.to_owned();
-        let _bucket = std::sync::Arc::new(Bucket {
-            creation_date: None,
-            name: Some(bucket_name.clone()),
-        });
         let region = match endpoint {
             Some(endpoint) => Region::Custom {
                 name: region

--- a/src/cache/s3.rs
+++ b/src/cache/s3.rs
@@ -15,9 +15,6 @@
 use crate::cache::{Cache, CacheRead, CacheWrite, Storage};
 use crate::errors::*;
 use directories::UserDirs;
-use futures_03::future::{self, Future};
-use futures_03::future::TryFutureExt as _;
-use hyper::Client;
 use hyper_rustls;
 use hyperx::header::CacheDirective;
 use rusoto_core::{
@@ -67,7 +64,7 @@ impl S3Cache {
         let provider =
             AutoRefreshingProvider::new(ChainProvider::with_profile_provider(profile_provider))?;
         let bucket_name = bucket.to_owned();
-        let bucket = std::sync::Arc::new(Bucket {
+        let _bucket = std::sync::Arc::new(Bucket {
             creation_date: None,
             name: Some(bucket_name.clone()),
         });

--- a/src/compiler/c.rs
+++ b/src/compiler/c.rs
@@ -23,7 +23,6 @@ use crate::dist;
 use crate::dist::pkg;
 use crate::mock_command::CommandCreatorSync;
 use crate::util::{hash_all, Digest, HashToDigest};
-use futures_03::Future;
 use futures_03::executor::ThreadPool;
 use std::borrow::Cow;
 use std::collections::{HashMap, HashSet};

--- a/src/compiler/compiler.rs
+++ b/src/compiler/compiler.rs
@@ -382,7 +382,7 @@ where
                             object_file_pretty: out_pretty2,
                             duration,
                         };
-                        tx.send(write_info);
+                        tx.send(write_info).expect("error, when sending information regarding object to cache."); //TODO: check if error message reflect actual intent
                         Ok::<_,anyhow::Error>(())
                     };
                     let _ = pool.spawn_with_handle(Box::pin(fut));
@@ -703,6 +703,7 @@ pub enum MissType {
 }
 
 /// Information about a successful cache write.
+#[derive(Debug)]
 pub struct CacheWriteInfo {
     pub object_file_pretty: String,
     pub duration: Duration,

--- a/src/compiler/compiler.rs
+++ b/src/compiler/compiler.rs
@@ -14,7 +14,7 @@
 
 #![allow(clippy::complexity)]
 
-use crate::cache::{Cache, CacheWrite, DecompressionFailure, Storage, ArcDynStorage, };
+use crate::cache::{Cache, CacheWrite, DecompressionFailure, ArcDynStorage, };
 use crate::compiler::c::{CCompiler, CCompilerKind};
 use crate::compiler::clang::Clang;
 use crate::compiler::diab::Diab;
@@ -29,12 +29,8 @@ use crate::dist::pkg;
 use crate::mock_command::{exit_status, CommandChild, CommandCreatorSync, RunCommand};
 use crate::util::{fmt_duration_as_secs, ref_env, run_input_output, SpawnExt};
 use filetime::FileTime;
-use futures_03::Future;
 use futures_03::channel::oneshot;
 use futures_03::executor::ThreadPool;
-use futures_03::prelude::*;
-use futures_03::task::SpawnExt as SpawnExt_03;
-use tokio_02::time::Timeout;
 use std::borrow::Cow;
 use std::collections::HashMap;
 use std::ffi::OsString;
@@ -46,7 +42,6 @@ use std::io::prelude::*;
 use std::path::{Path, PathBuf};
 use std::process::{self, Stdio};
 use std::str;
-use std::sync::Arc;
 use std::time::{Duration, Instant};
 use tempfile::TempDir;
 
@@ -308,7 +303,7 @@ where
                 error!("[{}]: Cache read error: {:?}", out_pretty, err);
                 Ok(CacheLookupResult::Miss(MissType::CacheReadError))
             }
-            Err(err) => {
+            Err(_err) => {
                 debug!(
                     "[{}]: Cache timed out {}",
                     out_pretty,
@@ -471,7 +466,7 @@ where
     };
 
     debug!("[{}]: Attempting distributed compilation", out_pretty);
-    let compile_out_pretty = out_pretty.clone();
+    let _compile_out_pretty = out_pretty.clone(); // TODO: double check if we want to call two times in two lines in a row like this
     let compile_out_pretty = out_pretty.clone();
     let compile_out_pretty3 = out_pretty.clone();
     let compile_out_pretty4 = out_pretty;

--- a/src/compiler/msvc.rs
+++ b/src/compiler/msvc.rs
@@ -102,7 +102,6 @@ impl CCompilerImpl for MSVC {
 fn from_local_codepage(bytes: &[u8]) -> io::Result<String> {
     Encoding::OEM.to_string(bytes)
 }
-use futures_03::task::SpawnExt as SpawnExt_03;
 
 /// Detect the prefix included in the output of MSVC's -showIncludes output.
 pub async fn detect_showincludes_prefix<T>(

--- a/src/compiler/rust.rs
+++ b/src/compiler/rust.rs
@@ -26,10 +26,7 @@ use crate::mock_command::{CommandCreatorSync, RunCommand};
 use crate::util::{fmt_duration_as_secs, hash_all, run_input_output, Digest};
 use crate::util::{ref_env, HashToDigest, OsStrExt, SpawnExt};
 use filetime::FileTime;
-use futures_03::Future;
-use futures_03::pin_mut;
 use futures_03::executor::ThreadPool;
-use futures_03::task::SpawnExt as SpawnExt_03;
 use log::Level::Trace;
 #[cfg(feature = "dist-client")]
 use lru_disk_cache::{LruCache, Meter};
@@ -227,7 +224,7 @@ where
         .envs(ref_env(env_vars))
         .current_dir(cwd);
     trace!("[{}]: get dep-info: {:?}", crate_name, cmd);
-    let dep_info = run_input_output(cmd, None).await?;
+    let _dep_info = run_input_output(cmd, None).await?;
     // Parse the dep-info file, then hash the contents of those files.
     let pool = pool.clone();
     let cwd = cwd.to_owned();

--- a/src/compiler/rust.rs
+++ b/src/compiler/rust.rs
@@ -224,7 +224,8 @@ where
         .envs(ref_env(env_vars))
         .current_dir(cwd);
     trace!("[{}]: get dep-info: {:?}", crate_name, cmd);
-    let _dep_info = run_input_output(cmd, None).await?;
+    // Output of command is in file under dep_file, so we ignore stdout&stderr
+    let _stdouterr = run_input_output(cmd, None).await?;
     // Parse the dep-info file, then hash the contents of those files.
     let pool = pool.clone();
     let cwd = cwd.to_owned();

--- a/src/dist/cache.rs
+++ b/src/dist/cache.rs
@@ -1,7 +1,6 @@
 use crate::dist::Toolchain;
 
 use anyhow::{anyhow, Result};
-use futures_03::task::SpawnExt;
 use lru_disk_cache::Result as LruResult;
 use lru_disk_cache::{LruDiskCache, ReadSeek};
 use std::fs;
@@ -16,7 +15,7 @@ use std::io::Read;
 #[cfg(feature = "dist-client")]
 mod client {
     use crate::config;
-    use crate::dist::pkg::{ToolchainPackager, BoxDynToolchainPackager};
+    use crate::dist::pkg::BoxDynToolchainPackager;
     use crate::dist::Toolchain;
     use anyhow::{bail, Context, Error, Result};
     use lru_disk_cache::Error as LruError;

--- a/src/dist/client_auth.rs
+++ b/src/dist/client_auth.rs
@@ -780,7 +780,8 @@ pub fn get_token_oauth2_code_grant_pkce(
     runtime
         .block_on(server.with_graceful_shutdown(async move {
             let _ = shutdown_signal.await;
-        } ))
+        } )).unwrap()
+        // TODO(drahnr): remove below when not needed anymore
         // .map_err(|e| {
         //     warn!(
         //         "Something went wrong while waiting for auth server shutdown: {}",

--- a/src/dist/client_auth.rs
+++ b/src/dist/client_auth.rs
@@ -1,19 +1,15 @@
-use futures_03::prelude::*;
 use futures_03::channel::oneshot;
 use futures_03::task as task_03;
 use http::StatusCode;
-use hyper::body::HttpBody;
 use hyper::server::conn::AddrIncoming;
 use hyper::service::Service;
 use hyper::{Body, Request, Response, Server};
 use hyperx::header::{ContentLength, ContentType};
 use serde::Serialize;
 use std::collections::HashMap;
-use std::error;
 use std::error::Error as StdError;
 use std::fmt;
 use std::io;
-use std::marker::PhantomData;
 use std::net::{TcpStream, ToSocketAddrs};
 use std::pin::Pin;
 use std::result;
@@ -126,7 +122,6 @@ mod code_grant_pkce {
         html_response, json_response, query_pairs, MIN_TOKEN_VALIDITY, MIN_TOKEN_VALIDITY_WARNING,
         REDIRECT_WITH_AUTH_JSON,
     };
-    use futures_03::future::{self, Future};
     use futures_03::channel::oneshot;
     use hyper::{Body, Method, Request, Response, StatusCode};
     use rand::RngCore;
@@ -287,7 +282,7 @@ mod code_grant_pkce {
 
         fn poll_ready(
             &mut self,
-            cx: &mut task_03::Context<'_>,
+            _cx: &mut task_03::Context<'_>,
         ) -> task_03::Poll<result::Result<(), Self::Error>> {
             task_03::Poll::Ready(Ok(()))
         }
@@ -318,7 +313,7 @@ mod code_grant_pkce {
             redirect_uri,
         };
         let client = reqwest::blocking::Client::new();
-        let mut res = client.post(token_url).json(&token_request).send()?;
+        let res = client.post(token_url).json(&token_request).send()?;
         if !res.status().is_success() {
             bail!(
                 "Sending code to {} failed, HTTP error: {}",
@@ -351,7 +346,6 @@ mod implicit {
         REDIRECT_WITH_AUTH_JSON,
     };
     use futures_03::channel::oneshot;
-    use futures_03::future;
     use hyper::{Body, Method, Request, Response, StatusCode};
     use std::collections::HashMap;
     use std::sync::mpsc;
@@ -510,7 +504,7 @@ mod implicit {
 
         fn poll_ready(
             &mut self,
-            cx: &mut task_03::Context<'_>,
+            _cx: &mut task_03::Context<'_>,
         ) -> task_03::Poll<result::Result<(), Self::Error>> {
             task_03::Poll::Ready(Ok(()))
         }
@@ -740,7 +734,7 @@ pub fn get_token_oauth2_code_grant_pkce(
 ) -> Result<String> {
     use code_grant_pkce::CodeGrant;
 
-    let spawner = ServiceSpawner::<CodeGrant, _>::new(move |stream: &AddrStream| {
+    let spawner = ServiceSpawner::<CodeGrant, _>::new(move |_stream: &AddrStream| {
         let f = Box::pin(async move { Ok(CodeGrant) });
         f as Pin<
             Box<
@@ -807,7 +801,7 @@ pub fn get_token_oauth2_code_grant_pkce(
 pub fn get_token_oauth2_implicit(client_id: &str, mut auth_url: Url) -> Result<String> {
     use implicit::Implicit;
 
-    let spawner = ServiceSpawner::<Implicit, _>::new(move |stream: &AddrStream| {
+    let spawner = ServiceSpawner::<Implicit, _>::new(move |_stream: &AddrStream| {
         let f = Box::pin(async move { Ok(Implicit) });
         f as Pin<
             Box<

--- a/src/dist/client_auth.rs
+++ b/src/dist/client_auth.rs
@@ -781,18 +781,14 @@ pub fn get_token_oauth2_code_grant_pkce(
     runtime
         .block_on(server.with_graceful_shutdown(async move {
             let _ = shutdown_signal.await;
-        } )).expect("Something went wrong while waiting for auth server shutdown.");
-    //.map_err(|e| {
-    //        warn!(
-    //            "Something went wrong while waiting for auth server shutdown: {}",
-    //            e
-    //        );
-    //        StdError{"Error"}
-    //    });
-    //match auth_srv_shutdown_result {
-    //    Ok(_) => Ok(()),
-    //    Err(_) => StdError{"ERROR"},
-    //}?;
+        } ))
+    .map_err(|e| {
+            warn!(
+                "Something went wrong while waiting for auth server shutdown: {}",
+                e
+            );
+            e
+        });
 
     info!("Server finished, using code to request token");
     let code = code_rx

--- a/src/dist/client_auth.rs
+++ b/src/dist/client_auth.rs
@@ -777,18 +777,22 @@ pub fn get_token_oauth2_code_grant_pkce(
     let shutdown_signal = shutdown_rx;
 
     let mut runtime = Runtime::new()?;
+    //let auth_srv_shutdown_result = 
     runtime
         .block_on(server.with_graceful_shutdown(async move {
             let _ = shutdown_signal.await;
-        } )).unwrap()
-        // TODO(drahnr): remove below when not needed anymore
-        // .map_err(|e| {
-        //     warn!(
-        //         "Something went wrong while waiting for auth server shutdown: {}",
-        //         e
-        //     )
-        // })?
-        ;
+        } )).expect("Something went wrong while waiting for auth server shutdown.");
+    //.map_err(|e| {
+    //        warn!(
+    //            "Something went wrong while waiting for auth server shutdown: {}",
+    //            e
+    //        );
+    //        StdError{"Error"}
+    //    });
+    //match auth_srv_shutdown_result {
+    //    Ok(_) => Ok(()),
+    //    Err(_) => StdError{"ERROR"},
+    //}?;
 
     info!("Server finished, using code to request token");
     let code = code_rx

--- a/src/dist/client_auth.rs
+++ b/src/dist/client_auth.rs
@@ -777,7 +777,8 @@ pub fn get_token_oauth2_code_grant_pkce(
     let shutdown_signal = shutdown_rx;
 
     let mut runtime = Runtime::new()?;
-    //let auth_srv_shutdown_result = 
+    // if the wait of the shutdown terminated unexpectedly, we assume it triggered and continue shutdown
+    let _ = 
     runtime
         .block_on(server.with_graceful_shutdown(async move {
             let _ = shutdown_signal.await;

--- a/src/dist/http.rs
+++ b/src/dist/http.rs
@@ -20,13 +20,9 @@ pub use self::server::{
     ClientAuthCheck, ClientVisibleMsg, Scheduler, ServerAuthCheck, HEARTBEAT_TIMEOUT,
 };
 
-use futures_03::task::SpawnExt;
-
 mod common {
     #[cfg(feature = "dist-client")]
-    use futures_03::{Future, Stream};
     #[cfg(feature = "dist-client")]
-    use futures_03::task::SpawnExt;
     use hyperx::header;
     #[cfg(feature = "dist-server")]
     use std::collections::HashMap;
@@ -1085,7 +1081,7 @@ mod server {
 mod client {
     use super::super::cache;
     use crate::config;
-    use crate::dist::pkg::{InputsPackager, BoxDynInputsPackager, ToolchainPackager, BoxDynToolchainPackager, };
+    use crate::dist::pkg::{BoxDynInputsPackager, BoxDynToolchainPackager, };
     use crate::dist::{
         self, AllocJobResult, CompileCommand, JobAlloc, PathTransformer, RunJobResult,
         SchedulerStatusResult, SubmitToolchainResult, Toolchain,
@@ -1094,7 +1090,6 @@ mod client {
     use byteorder::{BigEndian, WriteBytesExt};
     use flate2::write::ZlibEncoder as ZlibWriteEncoder;
     use flate2::Compression;
-    use futures_03::Future;
     use futures_03::executor::ThreadPool;
     use futures_03::task::SpawnExt as SpawnExt_03;
     use std::collections::HashMap;

--- a/src/dist/http.rs
+++ b/src/dist/http.rs
@@ -1249,7 +1249,7 @@ mod client {
                         &mut server_certs.lock().unwrap(),
                         res.cert_digest,
                         res.cert_pem,
-                    );
+                    ).unwrap();
 
                     alloc_job_res
                 }

--- a/src/dist/http.rs
+++ b/src/dist/http.rs
@@ -1249,7 +1249,7 @@ mod client {
                         &mut server_certs.lock().unwrap(),
                         res.cert_digest,
                         res.cert_pem,
-                    ).unwrap();
+                    ).context("Failed to update certificate").unwrap_or_else(|e| { warn!("Failed to update certificate: {:?}", e) });
 
                     alloc_job_res
                 }

--- a/src/dist/mod.rs
+++ b/src/dist/mod.rs
@@ -19,7 +19,7 @@ use std::ffi::OsString;
 use std::fmt;
 use std::io::{self, Read};
 use std::net::SocketAddr;
-use std::path::{Path, PathBuf};
+use std::path::PathBuf;
 use std::process;
 use std::sync::Arc;
 use std::str::FromStr;

--- a/src/jobserver.rs
+++ b/src/jobserver.rs
@@ -1,11 +1,9 @@
 use std::io;
 use std::sync::Arc;
-use tokio_02::process::Command;
 use std::process::Command as StdCommand;
 
 use futures_03::channel::mpsc;
 use futures_03::channel::oneshot;
-use futures_03::future;
 use futures_03::prelude::*;
 
 use crate::errors::*;
@@ -39,7 +37,7 @@ impl Client {
         let (helper, tx) = if inherited {
             (None, None)
         } else {
-            let (mut tx, mut rx) = mpsc::unbounded::<oneshot::Sender<_>>();
+            let (tx, mut rx) = mpsc::unbounded::<oneshot::Sender<_>>();
             let helper = inner
                 .clone()
                 .into_helper_thread(move |token| {

--- a/src/mock_command.rs
+++ b/src/mock_command.rs
@@ -47,7 +47,6 @@
 
 use crate::errors::*;
 use crate::jobserver::{Acquired, Client};
-use futures_03::future::{self, Future};
 use std::boxed::Box;
 use std::ffi::{OsStr, OsString};
 use std::fmt;
@@ -57,7 +56,7 @@ use std::process::{ExitStatus, Output, Stdio};
 use std::result;
 use std::sync::{Arc, Mutex};
 use tokio_02::io::{AsyncRead, AsyncWrite};
-use tokio_02::process::{self, ChildStderr, ChildStdin, ChildStdout};
+use tokio_02::process::{ChildStderr, ChildStdin, ChildStdout};
 use std::process::Command as StdCommand;
 
 /// A trait that provides a subset of the methods of `std::process::Child`.

--- a/src/server.rs
+++ b/src/server.rs
@@ -1265,7 +1265,7 @@ where
                 }
             };
             let send = Box::pin(
-                tx.send(Ok(Response::CompileFinished(res))).map_err(|_e| anyhow!("send on finish failed") )
+                tx.send(Ok(Response::CompileFinished(res))).map_err(|e| anyhow!("send on finish failed").context(e) )
             );
 
             let me = me.clone();

--- a/src/server.rs
+++ b/src/server.rs
@@ -16,7 +16,7 @@
 #![allow(deprecated)]
 #![allow(clippy::complexity)]
 
-use crate::cache::{storage_from_config, Storage, ArcDynStorage};
+use crate::cache::{storage_from_config, ArcDynStorage};
 use crate::compiler::{
     get_compiler_info, CacheControl, CompileResult, Compiler, CompilerArguments, CompilerHasher,
     CompilerKind, CompilerProxy, DistType, MissType,
@@ -34,14 +34,13 @@ use crate::util;
 use anyhow::Context as _;
 use bytes::{buf::ext::BufMutExt, Bytes, BytesMut};
 use filetime::FileTime;
-use futures_03::{Future as _, pin_mut};
 use futures_03::executor::ThreadPool;
 use futures_03::task::SpawnExt;
-use futures_03::{channel::mpsc, compat::*, future, prelude::*, stream};
+use futures_03::{channel::mpsc, future, prelude::*, stream};
 use futures_03::future::FutureExt;
 use futures_locks::RwLock;
 use number_prefix::{binary_prefix, Prefixed, Standalone};
-use std::{borrow::BorrowMut, collections::HashMap};
+use std::collections::HashMap;
 use std::env;
 use std::ffi::{OsStr, OsString};
 use std::fs::metadata;
@@ -571,7 +570,7 @@ impl<C: CommandCreatorSync> SccacheServer<C> {
             info!("shutting down due to explicit signal");
         });
 
-        let mut shutdown_or_inactive = async {
+        let shutdown_or_inactive = async {
             ShutdownOrInactive {
                 rx,
                 timeout: if timeout != Duration::new(0, 0) {
@@ -1266,7 +1265,7 @@ where
                 }
             };
             let send = Box::pin(
-                tx.send(Ok(Response::CompileFinished(res))).map_err(|e| anyhow!("send on finish failed") )
+                tx.send(Ok(Response::CompileFinished(res))).map_err(|_e| anyhow!("send on finish failed") )
             );
 
             let me = me.clone();

--- a/src/server.rs
+++ b/src/server.rs
@@ -748,7 +748,7 @@ where
                 }
                 Request::ZeroStats => {
                     debug!("handle_client: zero_stats");
-                    me.zero_stats();
+                    me.zero_stats().await;
                     me
                         .get_info()
                         .await
@@ -1297,7 +1297,7 @@ where
             Ok::<_, Error>(())
         };
 
-        self.pool.spawn(Box::pin(async move { task.await; } )).unwrap();
+        self.pool.spawn(Box::pin(async move { task.await.unwrap(); } )).unwrap();
     }
 }
 

--- a/src/server.rs
+++ b/src/server.rs
@@ -1297,7 +1297,7 @@ where
             Ok::<_, Error>(())
         };
 
-        self.pool.spawn(Box::pin(async move { task.await.unwrap(); } )).unwrap();
+        self.pool.spawn(Box::pin(async move { task.await.unwrap_or_else(|e| { warn!("Failed to execut task: {:?}", e) }); } )).expect("Spawning on the worker pool never fails. qed");
     }
 }
 

--- a/src/util.rs
+++ b/src/util.rs
@@ -190,7 +190,7 @@ where
     // Finish writing stdin before waiting, because waiting drops stdin.
 
     if let Some(stdin) = stdin {
-        stdin.await.unwrap();
+        let _ = stdin.await;
     }
     let status = child.wait().await.context("failed to wait for child")?;
     let (stdout, stderr) = futures_03::join!(stdout, stderr);

--- a/src/util.rs
+++ b/src/util.rs
@@ -418,7 +418,7 @@ mod http_extension {
     }
 
     impl RequestExt for http::request::Builder {
-        fn set_header<H>(mut self, header: H) -> Self
+        fn set_header<H>(self, header: H) -> Self
         where
             H: hyperx::header::Header + fmt::Display,
         {

--- a/src/util.rs
+++ b/src/util.rs
@@ -16,13 +16,8 @@ use crate::mock_command::{CommandChild, RunCommand};
 use blake3::Hasher as blake3_Hasher;
 use byteorder::{BigEndian, ByteOrder};
 use futures_03::executor::ThreadPool;
-use futures_03::future::TryFutureExt;
-use futures_03::task;
 pub(crate) use futures_03::task::SpawnExt;
-use futures_03::TryStreamExt;
-use futures_03::{compat::Future01CompatExt, future, pin_mut, stream::FuturesUnordered};
 use serde::Serialize;
-use std::convert::TryFrom;
 use std::ffi::{OsStr, OsString};
 use std::fs::File;
 use std::hash::Hasher;
@@ -157,9 +152,7 @@ async fn wait_with_input_output<T>(mut child: T, input: Option<Vec<u8>>) -> Resu
 where
     T: CommandChild + 'static,
 {
-    use tokio_02::io::{AsyncReadExt, BufReader};
-    use tokio_02::io::{AsyncWriteExt, BufWriter};
-    use tokio_02::process::Command;
+    use tokio_02::io::{AsyncReadExt,AsyncWriteExt};
     let stdin = input.and_then(|i| {
         child.take_stdin().map(|mut stdin| {
             Box::pin(async move { stdin.write_all(&i).await.context("failed to write stdin") })
@@ -382,9 +375,7 @@ pub use self::http_extension::{HeadersExt, RequestExt};
 // TODO delete all of it
 #[cfg(feature = "hyperx")]
 mod http_extension {
-    use std::convert::TryFrom;
-
-    use reqwest::header::{HeaderMap, HeaderValue, InvalidHeaderName, InvalidHeaderValue};
+    use reqwest::header::{HeaderMap, HeaderValue};
     use std::fmt;
 
     pub trait HeadersExt {
@@ -440,7 +431,7 @@ mod http_extension {
     }
 
     impl RequestExt for http::response::Builder {
-        fn set_header<H>(mut self, header: H) -> Self
+        fn set_header<H>(self, header: H) -> Self
         where
             H: hyperx::header::Header + fmt::Display,
         {

--- a/src/util.rs
+++ b/src/util.rs
@@ -190,7 +190,7 @@ where
     // Finish writing stdin before waiting, because waiting drops stdin.
 
     if let Some(stdin) = stdin {
-        stdin.await;
+        stdin.await.unwrap();
     }
     let status = child.wait().await.context("failed to wait for child")?;
     let (stdout, stderr) = futures_03::join!(stdout, stderr);

--- a/tests/harness/mod.rs
+++ b/tests/harness/mod.rs
@@ -448,11 +448,11 @@ impl DistSystem {
         HTTPUrl::from_url(reqwest::Url::parse(&url).unwrap())
     }
 
-    fn scheduler_status(&self) -> SchedulerStatusResult {
+    async fn scheduler_status(&self) -> SchedulerStatusResult {
         let res = reqwest::get(dist::http::urls::scheduler_status(
             &self.scheduler_url().to_url(),
-        ))
-        .unwrap();
+        )); //.unwrap();
+        let res = res.await.unwrap();
         assert!(res.status().is_success());
         bincode::deserialize_from(res).unwrap()
     }

--- a/tests/harness/mod.rs
+++ b/tests/harness/mod.rs
@@ -451,8 +451,7 @@ impl DistSystem {
     async fn scheduler_status(&self) -> SchedulerStatusResult {
         let res = reqwest::get(dist::http::urls::scheduler_status(
             &self.scheduler_url().to_url(),
-        )); //.unwrap();
-        let res = res.await.unwrap();
+        )).await.expect("Test code itself is perfect. qed");
         assert!(res.status().is_success());
         bincode::deserialize_from(res).unwrap()
     }


### PR DESCRIPTION
PTAL.

errors:
* unused Results (+= unwrap() or expect())
* unused Futures (+= .await)

fixed sources of warnings about: mut, unused variables.