### PR TITLE
Fix unit tests in the future migration branch

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -984,6 +984,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "futures-timer"
+version = "3.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e64b03909df88034c26dc1547e8970b91f98bdb65165d6a4e9110d94263dbb2c"
+
+[[package]]
 name = "futures-util"
 version = "0.3.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2933,6 +2939,7 @@ dependencies = [
  "futures 0.1.29",
  "futures 0.3.5",
  "futures-locks",
+ "futures-timer",
  "hmac 0.10.1",
  "http 0.2.1",
  "hyper 0.13.9",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,6 +37,7 @@ flate2 = { version = "1.0", optional = true, default-features = false, features 
 futures = "^0.1.11"
 futures_03 = { package = "futures", version = "0.3", features = ["compat", "thread-pool"] }
 futures-locks = "0.6"
+futures-timer = "3"
 
 hmac = { version = "0.10", optional = true }
 http = "^0.2.1"


### PR DESCRIPTION
This PR fixes some of the issues that came up in the migration rewrite, working around some Tokio quirks (see commit comments).

The unit tests pass locally for me but `sccache_cargo` integration test still fails.