### PR TITLE
Fix compilation in futures branch when not using default features

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -85,7 +85,7 @@ tempfile = "3"
 # which is necessary for some trait objects
 thiserror = "1"
 time = "0.1.35"
-tokio_02 = { package = "tokio", version = "0.2", features = ["io-util", "time", "uds"] }
+tokio_02 = { package = "tokio", version = "0.2", features = ["io-util", "time", "uds", "tcp", "process"] }
 tokio-compat = "0.1"
 tokio-io = "0.1"
 tokio-process = "0.2"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -149,7 +149,7 @@ default = ["redis", "s3", "memcached", "gcs", "azure", "dist-client", "dist-serv
 # legacy compat, do not use
 all = ["redis", "s3", "memcached", "gcs", "azure", "dist-client", "dist-server"]
 
-azure = ["chrono", "hyper", "hyperx", "url", "hmac", "md-5", "sha2"]
+azure = ["chrono", "hyper", "hyperx", "reqwest", "url", "hmac", "md-5", "sha2"]
 s3 = ["chrono", "hyper", "hyper-rustls", "hyperx", "reqwest", "rusoto_core", "rusoto_s3", "hmac", "sha-1"]
 simple-s3 = []
 gcs = ["chrono", "hyper", "hyperx", "reqwest", "ring", "untrusted", "url", "sha2"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -162,7 +162,7 @@ unstable = []
 # Enables distributed support in the sccache client
 dist-client = ["ar", "flate2", "hyper", "hyperx", "reqwest", "url", "sha2"]
 # Enables the sccache-dist binary
-dist-server = ["crossbeam-utils", "jsonwebtoken", "flate2", "libmount", "nix", "reqwest", "rouille", "syslog", "void", "version-compare"]
+dist-server = ["chrono", "crossbeam-utils", "hyperx", "jsonwebtoken", "flate2", "libmount", "nix", "reqwest", "rouille", "sha2", "syslog", "void", "version-compare"]
 # Enables dist tests with external requirements
 dist-tests = ["dist-client", "dist-server"]
 # Run JWK token crypto against openssl ref impl

--- a/src/compiler/compiler.rs
+++ b/src/compiler/compiler.rs
@@ -409,7 +409,7 @@ where
 
 #[cfg(not(feature = "dist-client"))]
 async fn dist_or_local_compile<T>(
-    _dist_client: Result<Option<dist::ArcDynClient>>,
+    _dist_client: Option<dist::ArcDynClient>,
     creator: T,
     _cwd: PathBuf,
     compilation: Box<dyn Compilation>,

--- a/src/compiler/rust.rs
+++ b/src/compiler/rust.rs
@@ -437,7 +437,7 @@ impl Rust {
         #[cfg(not(feature = "dist-client"))]
         {
             let (sysroot, libs) = sysroot_and_libs.await?;
-            hash_all(&libs, &pool).map(move |digests| Rust {
+            hash_all(&libs, &pool).await.map(move |digests| Rust {
                 executable,
                 host,
                 sysroot,

--- a/src/dist/http.rs
+++ b/src/dist/http.rs
@@ -21,8 +21,7 @@ pub use self::server::{
 };
 
 mod common {
-    #[cfg(feature = "dist-client")]
-    #[cfg(feature = "dist-client")]
+    #[cfg(any(feature = "dist-client", feature = "dist-server"))]
     use hyperx::header;
     #[cfg(feature = "dist-server")]
     use std::collections::HashMap;

--- a/src/dist/mod.rs
+++ b/src/dist/mod.rs
@@ -50,7 +50,9 @@ pub mod pkg;
 #[cfg(not(feature = "dist-client"))]
 mod pkg {
     pub trait ToolchainPackager {}
+    pub type BoxDynToolchainPackager = Box<dyn ToolchainPackager>;
     pub trait InputsPackager {}
+    pub type BoxDynInputsPackager = Box<dyn InputsPackager>;
 }
 
 #[cfg(target_os = "windows")]


### PR DESCRIPTION
This was checked and tested with `--no-default-features` either alone or combined with a single storage backend feature (`azure`, `s3` etc.)