### PR TITLE
Further tweaks to the futures migration PR

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2929,7 +2929,6 @@ dependencies = [
  "env_logger",
  "filetime",
  "flate2",
- "futures 0.1.29",
  "futures 0.3.5",
  "futures-locks",
  "hmac 0.10.1",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,8 +34,7 @@ directories = "3"
 env_logger = "0.8"
 filetime = "0.2"
 flate2 = { version = "1.0", optional = true, default-features = false, features = ["rust_backend"] }
-futures = "^0.1.11"
-futures_03 = { package = "futures", version = "0.3", features = ["compat"] }
+futures = "0.3"
 futures-locks = "0.6"
 
 hmac = { version = "0.10", optional = true }
@@ -85,7 +84,7 @@ tempfile = "3"
 # which is necessary for some trait objects
 thiserror = "1"
 time = "0.1.35"
-tokio_02 = { package = "tokio", version = "0.2", features = ["io-util", "time", "uds", "tcp", "process"] }
+tokio = { version = "0.2", features = ["io-util", "time", "uds", "tcp", "process"] }
 tokio-compat = "0.1"
 tokio-io = "0.1"
 tokio-process = "0.2"

--- a/src/azure/blobstore.rs
+++ b/src/azure/blobstore.rs
@@ -272,7 +272,7 @@ fn canonicalize_resource(uri: &Url, account_name: &str) -> String {
 #[cfg(test)]
 mod test {
     use super::*;
-    use tokio_02::runtime::Runtime;
+    use tokio::runtime::Runtime;
 
     #[test]
     fn test_signing() {

--- a/src/bin/sccache-dist/build.rs
+++ b/src/bin/sccache-dist/build.rs
@@ -416,7 +416,7 @@ impl OverlayBuilder {
                 .join()
                 .unwrap_or_else(|_e| Err(anyhow!("Build thread exited unsuccessfully")))
         })
-        .map_err(|_e| anyhow!("Failed to join thread"))?
+        .unwrap_or_else(|e| Err(anyhow!("Error joining build thread: {:?}", e)))
     }
 
     // Failing during cleanup is pretty unexpected, but we can still return the successful compile

--- a/src/cache/azure.rs
+++ b/src/cache/azure.rs
@@ -68,13 +68,13 @@ impl Storage for AzureBlobCache {
         let start = Instant::now();
         let data = entry.finish()?;
 
-        let response = self
+        let _ = self
             .container
             .put(key, data, &self.credentials)
             .await
-            .map_err(|e| e.context("Failed to put cache entry in Azure"))
-            .map(move |_| start.elapsed())?;
-        Ok(response)
+            .context("Failed to put cache entry in Azure")?;
+
+        Ok(start.elapsed())
     }
 
     fn location(&self) -> String {

--- a/src/cache/cache.rs
+++ b/src/cache/cache.rs
@@ -150,7 +150,7 @@ impl CacheRead {
         bytes
     }
 
-    pub async fn extract_objects<T>(mut self, objects: T, pool: &tokio_02::runtime::Handle) -> Result<()>
+    pub async fn extract_objects<T>(mut self, objects: T, pool: &tokio::runtime::Handle) -> Result<()>
     where
         T: IntoIterator<Item = (String, PathBuf)> + Send + Sync + 'static,
     {
@@ -190,7 +190,7 @@ impl CacheWrite {
     }
 
     /// Create a new cache entry populated with the contents of `objects`.
-    pub async fn from_objects<T>(objects: T, pool: &tokio_02::runtime::Handle) -> Result<CacheWrite>
+    pub async fn from_objects<T>(objects: T, pool: &tokio::runtime::Handle) -> Result<CacheWrite>
     where
         T: IntoIterator<Item = (String, PathBuf)> + Send + Sync + 'static,
     {
@@ -291,7 +291,7 @@ pub trait Storage: Send {
 
 /// Get a suitable `Storage` implementation from configuration.
 #[allow(clippy::cognitive_complexity)] // TODO simplify!
-pub fn storage_from_config(config: &Config, pool: &tokio_02::runtime::Handle) -> ArcDynStorage {
+pub fn storage_from_config(config: &Config, pool: &tokio::runtime::Handle) -> ArcDynStorage {
     for cache_type in config.caches.iter() {
         match *cache_type {
             CacheType::Azure(config::AzureCacheConfig) => {

--- a/src/cache/cache.rs
+++ b/src/cache/cache.rs
@@ -91,7 +91,7 @@ impl<T: Read + Seek + Send> ReadSeek for T {}
 
 /// Data stored in the compiler cache.
 pub struct CacheRead {
-    zip: ZipArchive<Box<dyn ReadSeek + Send>>,
+    zip: ZipArchive<Box<dyn ReadSeek>>,
 }
 
 /// Represents a failure to decompress stored object data.
@@ -110,9 +110,9 @@ impl CacheRead {
     /// Create a cache entry from `reader`.
     pub fn from<R>(reader: R) -> Result<CacheRead>
     where
-        R: ReadSeek + Send + 'static,
+        R: ReadSeek + 'static,
     {
-        let z = ZipArchive::new(Box::new(reader) as _)
+        let z = ZipArchive::new(Box::new(reader) as Box<dyn ReadSeek>)
             .context("Failed to parse cache entry")?;
         Ok(CacheRead { zip: z })
     }

--- a/src/cache/cache.rs
+++ b/src/cache/cache.rs
@@ -257,8 +257,6 @@ impl Default for CacheWrite {
     }
 }
 
-pub type ArcDynStorage = Arc<dyn Storage + Send + Sync>;
-
 /// An interface to cache storage.
 #[async_trait]
 pub trait Storage: Send {
@@ -289,7 +287,7 @@ pub trait Storage: Send {
 
 /// Get a suitable `Storage` implementation from configuration.
 #[allow(clippy::cognitive_complexity)] // TODO simplify!
-pub fn storage_from_config(config: &Config, pool: &tokio::runtime::Handle) -> ArcDynStorage {
+pub fn storage_from_config(config: &Config, pool: &tokio::runtime::Handle) -> Arc<dyn Storage + Send + Sync> {
     for cache_type in config.caches.iter() {
         match *cache_type {
             CacheType::Azure(config::AzureCacheConfig) => {

--- a/src/cache/disk.rs
+++ b/src/cache/disk.rs
@@ -74,8 +74,7 @@ impl Storage for DiskCache {
             let hit = CacheRead::from(io)?;
             Ok(Cache::Hit(hit))
         })
-        .await
-        .map_err(anyhow::Error::from)?
+        .await?
     }
 
     async fn put(&self, key: &str, entry: CacheWrite) -> Result<Duration> {
@@ -91,8 +90,7 @@ impl Storage for DiskCache {
             lru.lock().unwrap().insert_bytes(key, &v)?;
             Ok(start.elapsed())
         })
-        .await
-        .map_err(anyhow::Error::from)?
+        .await?
     }
 
     fn location(&self) -> String {

--- a/src/cache/disk.rs
+++ b/src/cache/disk.rs
@@ -28,12 +28,12 @@ pub struct DiskCache {
     /// `LruDiskCache` does all the real work here.
     lru: Arc<Mutex<LruDiskCache>>,
     /// Thread pool to execute disk I/O
-    pool: tokio_02::runtime::Handle,
+    pool: tokio::runtime::Handle,
 }
 
 impl DiskCache {
     /// Create a new `DiskCache` rooted at `root`, with `max_size` as the maximum cache size on-disk, in bytes.
-    pub fn new<T: AsRef<OsStr>>(root: &T, max_size: u64, pool: &tokio_02::runtime::Handle) -> DiskCache {
+    pub fn new<T: AsRef<OsStr>>(root: &T, max_size: u64, pool: &tokio::runtime::Handle) -> DiskCache {
         DiskCache {
             //TODO: change this function to return a Result
             lru: Arc::new(Mutex::new(

--- a/src/cache/gcs.rs
+++ b/src/cache/gcs.rs
@@ -18,7 +18,7 @@ use crate::{
     errors::*,
     util::HeadersExt,
 };
-use futures_03::future::Shared;
+use futures::future::Shared;
 use hyper::Method;
 use hyperx::header::{Authorization, Bearer, ContentLength, ContentType};
 use reqwest::{Client, Request};
@@ -30,7 +30,7 @@ use url::{
     percent_encoding::{percent_encode, PATH_SEGMENT_ENCODE_SET, QUERY_ENCODE_SET},
 };
 // use ::ReqwestRequestBuilderExt;
-use futures_03::FutureExt;
+use futures::FutureExt;
 
 #[derive(thiserror::Error, Debug, Clone)]
 pub enum Error {
@@ -191,7 +191,7 @@ pub struct GCSCredentialProvider {
                     Box<
                         dyn 'static
                             + Send
-                            + futures_03::Future<Output = result::Result<GCSCredential, Error>>,
+                            + futures::Future<Output = result::Result<GCSCredential, Error>>,
                     >,
                 >,
             >,
@@ -493,7 +493,7 @@ impl GCSCredentialProvider {
                             Box<
                                 dyn 'static
                                     + Send
-                                    + futures_03::Future<
+                                    + futures::Future<
                                         Output = result::Result<GCSCredential, Error>,
                                     >,
                             >,
@@ -505,7 +505,7 @@ impl GCSCredentialProvider {
                             Box<
                                 dyn 'static
                                     + Send
-                                    + futures_03::Future<
+                                    + futures::Future<
                                         Output = result::Result<GCSCredential, Error>,
                                     >,
                             >,
@@ -593,7 +593,7 @@ impl Storage for GCSCache {
     }
 }
 
-use futures_03::TryFutureExt;
+use futures::TryFutureExt;
 
 #[test]
 fn test_gcs_credential_provider() {
@@ -611,7 +611,7 @@ fn test_gcs_credential_provider() {
     });
 
 
-    let mut rt = tokio_02::runtime::Runtime::new().unwrap();
+    let mut rt = tokio::runtime::Runtime::new().unwrap();
 
     let fut = async move {
     let server = hyper::Server::bind(&addr).serve(make_service);

--- a/src/cache/gcs.rs
+++ b/src/cache/gcs.rs
@@ -368,9 +368,9 @@ impl GCSCredentialProvider {
 
         let token_msg = if res.status().is_success() {
             let token_msg = res.json::<TokenMsg>().await?;
-            Result::Ok(token_msg)
+            Ok(token_msg)
         } else {
-            Err(BadHttpStatusError(res.status()).into())
+            Err(BadHttpStatusError(res.status()))
         }?;
 
         Ok(GCSCredential {

--- a/src/cache/gcs.rs
+++ b/src/cache/gcs.rs
@@ -24,7 +24,7 @@ use hyperx::header::{Authorization, Bearer, ContentLength, ContentType};
 use reqwest::{Client, Request};
 use serde::de;
 use std::{convert::Infallible, sync};
-use std::{fmt, io, pin::Pin, result, sync::Arc, time};
+use std::{fmt, future::Future, io, pin::Pin, result, sync::Arc, time};
 use url::{
     form_urlencoded,
     percent_encoding::{percent_encode, PATH_SEGMENT_ENCODE_SET, QUERY_ENCODE_SET},
@@ -191,7 +191,7 @@ pub struct GCSCredentialProvider {
                     Box<
                         dyn 'static
                             + Send
-                            + futures::Future<Output = result::Result<GCSCredential, Error>>,
+                            + Future<Output = result::Result<GCSCredential, Error>>,
                     >,
                 >,
             >,
@@ -493,7 +493,7 @@ impl GCSCredentialProvider {
                             Box<
                                 dyn 'static
                                     + Send
-                                    + futures::Future<
+                                    + Future<
                                         Output = result::Result<GCSCredential, Error>,
                                     >,
                             >,
@@ -505,7 +505,7 @@ impl GCSCredentialProvider {
                             Box<
                                 dyn 'static
                                     + Send
-                                    + futures::Future<
+                                    + Future<
                                         Output = result::Result<GCSCredential, Error>,
                                     >,
                             >,
@@ -592,8 +592,6 @@ impl Storage for GCSCache {
         Ok(None)
     }
 }
-
-use futures::TryFutureExt;
 
 #[test]
 fn test_gcs_credential_provider() {

--- a/src/cache/memcached.rs
+++ b/src/cache/memcached.rs
@@ -32,11 +32,11 @@ thread_local! {
 #[derive(Clone)]
 pub struct MemcachedCache {
     url: String,
-    pool: tokio_02::runtime::Handle,
+    pool: tokio::runtime::Handle,
 }
 
 impl MemcachedCache {
-    pub fn new(url: &str, pool: &tokio_02::runtime::Handle) -> Result<MemcachedCache> {
+    pub fn new(url: &str, pool: &tokio::runtime::Handle) -> Result<MemcachedCache> {
         Ok(MemcachedCache {
             url: url.to_owned(),
             pool: pool.clone(),

--- a/src/cache/memcached.rs
+++ b/src/cache/memcached.rs
@@ -22,7 +22,6 @@ use memcached::proto::Operation;
 use memcached::proto::ProtoType::Binary;
 use std::cell::RefCell;
 use std::io::Cursor;
-
 use std::time::{Duration, Instant};
 
 thread_local! {
@@ -77,8 +76,7 @@ impl Storage for MemcachedCache {
             .map(|(d, _)| CacheRead::from(Cursor::new(d)).map(Cache::Hit))
             .unwrap_or(Ok(Cache::Miss))
         })
-        .await
-        .map_err(anyhow::Error::from)?
+        .await?
     }
 
     async fn put(&self, key: &str, entry: CacheWrite) -> Result<Duration> {
@@ -91,8 +89,7 @@ impl Storage for MemcachedCache {
             me.exec(|c| c.set_noreply(&key.as_bytes(), &d, 0, 0))?;
             Ok(start.elapsed())
         })
-        .await
-        .map_err(anyhow::Error::from)?
+        .await?
     }
 
     fn location(&self) -> String {

--- a/src/cache/redis.rs
+++ b/src/cache/redis.rs
@@ -47,8 +47,6 @@ impl RedisCache {
 impl Storage for RedisCache {
     /// Open a connection and query for a key.
     async fn get(&self, key: &str) -> Result<Cache> {
-        // TODO keep one connection alive instead of creating a new one for each and every
-        // TODO get request.
         let mut c = self.connect().await?;
         let d: Vec<u8> = cmd("GET").arg(key).query_async(&mut c).await?;
         if d.is_empty() {

--- a/src/cache/s3.rs
+++ b/src/cache/s3.rs
@@ -26,7 +26,7 @@ use rusoto_s3::{GetObjectOutput, GetObjectRequest, PutObjectRequest, S3Client, S
 use std::io;
 use std::str::FromStr;
 use std::time::{Duration, Instant};
-use tokio_02::io::AsyncReadExt as _;
+use tokio::io::AsyncReadExt as _;
 
 /// A cache that stores entries in Amazon S3.
 pub struct S3Cache {

--- a/src/commands.rs
+++ b/src/commands.rs
@@ -32,9 +32,9 @@ use std::io::{self, Write};
 #[cfg(unix)]
 use std::os::unix::process::ExitStatusExt;
 use std::path::Path;
+use std::process;
 use strip_ansi_escapes::Writer;
 use tokio::io::AsyncReadExt;
-use tokio::process;
 use tokio::runtime::Runtime;
 use which::which_in;
 
@@ -79,12 +79,11 @@ fn run_server_process() -> Result<ServerStartup> {
     let socket_path = tempdir.path().join("sock");
     let mut runtime = Runtime::new()?;
     let exe_path = env::current_exe()?;
-    let _child = runtime.enter(|| process::Command::new(exe_path)
+    let _child = process::Command::new(exe_path)
         .env("SCCACHE_START_SERVER", "1")
         .env("SCCACHE_STARTUP_NOTIFY", &socket_path)
         .env("RUST_BACKTRACE", "1")
-        .spawn()
-    )?;
+        .spawn()?;
 
     let startup = async move {
         let mut listener = tokio::net::UnixListener::bind(&socket_path)?;

--- a/src/commands.rs
+++ b/src/commands.rs
@@ -23,7 +23,7 @@ use crate::server::{self, DistInfo, ServerInfo, ServerStartup};
 use crate::util::daemonize;
 use atty::Stream;
 use byteorder::{BigEndian, ByteOrder};
-use futures::StreamExt;
+use futures::{FutureExt, StreamExt};
 use log::Level::Trace;
 use std::{env, process::ExitStatus};
 use std::ffi::{OsStr, OsString};
@@ -54,8 +54,7 @@ fn get_port() -> u16 {
         .unwrap_or(DEFAULT_PORT)
 }
 
-async fn read_server_startup_status<R: AsyncReadExt>(server: R) -> Result<ServerStartup> {
-    let mut server = Box::pin(server);
+async fn read_server_startup_status<R: AsyncReadExt + Unpin>(mut server: R) -> Result<ServerStartup> {
     // This is an async equivalent of ServerConnection::read_one_response
     let mut bytes = [0u8; 4];
     server.read_exact(&mut bytes[..]).await?;
@@ -87,24 +86,19 @@ fn run_server_process() -> Result<ServerStartup> {
 
     let startup = async move {
         let mut listener = tokio::net::UnixListener::bind(&socket_path)?;
-        let mut listener = listener.incoming();
-        match listener.next().await.expect("UnixListener::incoming() never returns `None`. qed") {
-            Ok(stream) => {
-                read_server_startup_status(stream).await
-            }
-            Err(e) => {
-                Ok(ServerStartup::Err{ reason: format!("Error {:?} ", e) } )
-            }
-        }
+        let socket = listener.incoming().next().await;
+        let socket = socket.unwrap(); // incoming() never returns None
+
+        read_server_startup_status(socket?).await
     };
 
     let timeout = Duration::from_millis(SERVER_STARTUP_TIMEOUT_MS.into());
-    let z = runtime.block_on(async move { tokio::time::timeout(timeout, startup).await } );
-
-    z
-    .or_else(|_err| {
-        Ok(Ok(ServerStartup::TimedOut))
-    }).and_then(|flatten| flatten)
+    runtime.block_on(async move {
+        match tokio::time::timeout(timeout, startup).await {
+            Ok(result) => result,
+            Err(_elapsed) => Ok(ServerStartup::TimedOut),
+        }
+    })
 }
 
 #[cfg(not(windows))]
@@ -508,16 +502,11 @@ where
     if log_enabled!(Trace) {
         trace!("running command: {:?}", cmd);
     }
-    let status = {
-        let fut = async move {
-            let child = cmd.spawn().await?;
-            let status = child.wait().await?;
-            Ok::<_,anyhow::Error>(status)
-        };
-        futures::pin_mut!(fut);
-        let status = runtime.block_on(fut)?;
-        status
-    };
+
+    let status = runtime.block_on(async move {
+        let child = cmd.spawn().await?;
+        child.wait().await.with_context(|| "failed to wait for a child")
+    })?;
 
     Ok(status.code().unwrap_or_else(|| {
         if let Some(sig) = status_signal(status) {

--- a/src/commands.rs
+++ b/src/commands.rs
@@ -23,7 +23,7 @@ use crate::server::{self, DistInfo, ServerInfo, ServerStartup};
 use crate::util::daemonize;
 use atty::Stream;
 use byteorder::{BigEndian, ByteOrder};
-use futures_03::StreamExt;
+use futures::StreamExt;
 use log::Level::Trace;
 use std::{env, process::ExitStatus};
 use std::ffi::{OsStr, OsString};
@@ -33,9 +33,9 @@ use std::io::{self, Write};
 use std::os::unix::process::ExitStatusExt;
 use std::path::Path;
 use strip_ansi_escapes::Writer;
-use tokio_02::io::AsyncReadExt;
-use tokio_02::process;
-use tokio_02::runtime::Runtime;
+use tokio::io::AsyncReadExt;
+use tokio::process;
+use tokio::runtime::Runtime;
 use which::which_in;
 
 use crate::errors::*;
@@ -87,7 +87,7 @@ fn run_server_process() -> Result<ServerStartup> {
     )?;
 
     let startup = async move {
-        let mut listener = tokio_02::net::UnixListener::bind(&socket_path)?;
+        let mut listener = tokio::net::UnixListener::bind(&socket_path)?;
         let mut listener = listener.incoming();
         match listener.next().await.expect("UnixListener::incoming() never returns `None`. qed") {
             Ok(stream) => {
@@ -100,7 +100,7 @@ fn run_server_process() -> Result<ServerStartup> {
     };
 
     let timeout = Duration::from_millis(SERVER_STARTUP_TIMEOUT_MS.into());
-    let z = runtime.block_on(async move { tokio_02::time::timeout(timeout, startup).await } );
+    let z = runtime.block_on(async move { tokio::time::timeout(timeout, startup).await } );
 
     z
     .or_else(|_err| {
@@ -144,7 +144,7 @@ fn redirect_error_log() -> Result<()> {
 /// Re-execute the current executable as a background server.
 #[cfg(windows)]
 fn run_server_process() -> Result<ServerStartup> {
-    use futures_03::future;
+    use futures::future;
     use std::mem;
     use std::os::windows::ffi::OsStrExt;
     use std::ptr;
@@ -248,7 +248,7 @@ fn run_server_process() -> Result<ServerStartup> {
 
     let timeout = Duration::from_millis(SERVER_STARTUP_TIMEOUT_MS.into());
     runtime.block_on(
-        tokio_02::time::timeout(timeout, result)
+        tokio::time::timeout(timeout, result)
     )
     .and_then(|x| x)
     .or_else(|err| {
@@ -515,7 +515,7 @@ where
             let status = child.wait().await?;
             Ok::<_,anyhow::Error>(status)
         };
-        futures_03::pin_mut!(fut);
+        futures::pin_mut!(fut);
         let status = runtime.block_on(fut)?;
         status
     };
@@ -677,7 +677,7 @@ pub fn run_command(cmd: Command) -> Result<i32> {
             use crate::compiler;
 
             trace!("Command::PackageToolchain({})", executable.display());
-            let mut runtime = tokio_02::runtime::Runtime::new()?;
+            let mut runtime = tokio::runtime::Runtime::new()?;
             let jobserver = unsafe { Client::new() };
             let creator = ProcessCommandCreator::new(&jobserver);
             let env: Vec<_> = env::vars_os().collect();

--- a/src/compiler/c.rs
+++ b/src/compiler/c.rs
@@ -14,7 +14,7 @@
 
 use crate::compiler::{
     Cacheable, ColorMode, Compilation, CompileCommand, Compiler, CompilerArguments, CompilerHasher,
-    CompilerKind, HashResult, BoxDynCompiler,
+    CompilerKind, HashResult,
 };
 #[cfg(feature = "dist-client")]
 use crate::compiler::{DistPackagers, NoopOutputsRewriter};
@@ -249,7 +249,7 @@ impl<T: CommandCreatorSync, I: CCompilerImpl> Compiler<T> for CCompiler<I> {
         }
     }
 
-    fn box_clone(&self) -> BoxDynCompiler<T> {
+    fn box_clone(&self) -> Box<dyn Compiler<T>> {
         Box::new((*self).clone())
     }
 }

--- a/src/compiler/c.rs
+++ b/src/compiler/c.rs
@@ -206,7 +206,7 @@ impl<I> CCompiler<I>
 where
     I: CCompilerImpl,
 {
-    pub async fn new(compiler: I, executable: PathBuf, pool: &tokio_02::runtime::Handle) -> Result<CCompiler<I>> {
+    pub async fn new(compiler: I, executable: PathBuf, pool: &tokio::runtime::Handle) -> Result<CCompiler<I>> {
         Digest::file(executable.clone(), pool)
             .await
             .map(move |digest| CCompiler {
@@ -264,7 +264,7 @@ where
         cwd: PathBuf,
         env_vars: Vec<(OsString, OsString)>,
         may_dist: bool,
-        pool: &tokio_02::runtime::Handle,
+        pool: &tokio::runtime::Handle,
         rewrite_includes_only: bool,
     ) -> Result<HashResult> {
         let CCompilerHasher {

--- a/src/compiler/c.rs
+++ b/src/compiler/c.rs
@@ -274,22 +274,18 @@ where
             compiler,
         } = *self;
 
-        let res = {
-            let compiler = compiler.clone();
-            let fut = compiler.preprocess(
-                creator,
-                &executable,
-                &parsed_args,
-                &cwd,
-                &env_vars,
-                may_dist,
-                rewrite_includes_only,
-            );
-            Box::pin(fut).await
-        };
+        let result = compiler.preprocess(
+            creator,
+            &executable,
+            &parsed_args,
+            &cwd,
+            &env_vars,
+            may_dist,
+            rewrite_includes_only,
+        ).await;
         let out_pretty = parsed_args.output_pretty().into_owned();
 
-        let result = res.map_err(|e| {
+        let result = result.map_err(|e| {
             debug!("[{}]: preprocessor failed: {:?}", out_pretty, e);
             e
         });

--- a/src/compiler/c.rs
+++ b/src/compiler/c.rs
@@ -224,7 +224,7 @@ impl<T: CommandCreatorSync, I: CCompilerImpl> Compiler<T> for CCompiler<I> {
         CompilerKind::C(self.compiler.kind())
     }
     #[cfg(feature = "dist-client")]
-    fn get_toolchain_packager(&self) -> pkg::BoxDynToolchainPackager {
+    fn get_toolchain_packager(&self) -> Box<dyn pkg::ToolchainPackager> {
         Box::new(CToolchainPackager {
             executable: self.executable.clone(),
             kind: self.compiler.kind(),

--- a/src/compiler/clang.rs
+++ b/src/compiler/clang.rs
@@ -71,20 +71,17 @@ impl CCompilerImpl for Clang {
     where
         T: CommandCreatorSync,
     {
-        let fut = Box::pin(async move {
-            gcc::preprocess(
-                creator,
-                executable,
-                parsed_args,
-                cwd,
-                env_vars,
-                may_dist,
-                self.kind(),
-                rewrite_includes_only,
-            )
-            .await
-        });
-        fut.await
+        gcc::preprocess(
+            creator,
+            executable,
+            parsed_args,
+            cwd,
+            env_vars,
+            may_dist,
+            self.kind(),
+            rewrite_includes_only,
+        )
+        .await
     }
 
     fn generate_compile_commands(

--- a/src/compiler/clang.rs
+++ b/src/compiler/clang.rs
@@ -21,9 +21,9 @@ use crate::compiler::{gcc, write_temp_file, Cacheable, CompileCommand, CompilerA
 use crate::dist;
 use crate::mock_command::{CommandCreator, CommandCreatorSync, RunCommand};
 use crate::util::{run_input_output, OsStrExt};
-use futures::future::{self, Future};
 use std::ffi::OsString;
 use std::fs::File;
+use std::future::Future;
 use std::io::{self, Write};
 use std::path::{Path, PathBuf};
 use std::process;
@@ -141,8 +141,8 @@ mod test {
     use crate::compiler::*;
     use crate::mock_command::*;
     use crate::test::utils::*;
-    use futures::Future;
     use std::collections::HashMap;
+    use std::future::Future;
     use std::path::PathBuf;
 
     fn parse_arguments_(arguments: Vec<String>) -> CompilerArguments<ParsedArguments> {

--- a/src/compiler/clang.rs
+++ b/src/compiler/clang.rs
@@ -21,7 +21,7 @@ use crate::compiler::{gcc, write_temp_file, Cacheable, CompileCommand, CompilerA
 use crate::dist;
 use crate::mock_command::{CommandCreator, CommandCreatorSync, RunCommand};
 use crate::util::{run_input_output, OsStrExt};
-use futures_03::future::{self, Future};
+use futures::future::{self, Future};
 use std::ffi::OsString;
 use std::fs::File;
 use std::io::{self, Write};
@@ -141,7 +141,7 @@ mod test {
     use crate::compiler::*;
     use crate::mock_command::*;
     use crate::test::utils::*;
-    use futures_03::Future;
+    use futures::Future;
     use std::collections::HashMap;
     use std::path::PathBuf;
 

--- a/src/compiler/compiler.rs
+++ b/src/compiler/compiler.rs
@@ -29,7 +29,7 @@ use crate::dist::pkg;
 use crate::mock_command::{exit_status, CommandChild, CommandCreatorSync, RunCommand};
 use crate::util::{fmt_duration_as_secs, ref_env, run_input_output, SpawnExt};
 use filetime::FileTime;
-use futures_03::{Future, channel::oneshot};
+use futures::{Future, channel::oneshot};
 use std::borrow::Cow;
 use std::collections::HashMap;
 use std::ffi::OsString;
@@ -178,7 +178,7 @@ where
         cwd: PathBuf,
         env_vars: Vec<(OsString, OsString)>,
         may_dist: bool,
-        pool: &tokio_02::runtime::Handle,
+        pool: &tokio::runtime::Handle,
         rewrite_includes_only: bool,
     ) -> Result<HashResult>;
 
@@ -197,7 +197,7 @@ where
         cwd: PathBuf,
         env_vars: Vec<(OsString, OsString)>,
         cache_control: CacheControl,
-        pool: tokio_02::runtime::Handle,
+        pool: tokio::runtime::Handle,
     ) -> Result<(CompileResult, process::Output)> {
 
         let out_pretty = self.output_pretty().into_owned();
@@ -244,7 +244,7 @@ where
         } else {
             let fetch = storage.get(&key);
 
-            tokio_02::time::timeout(Duration::from_secs(60), fetch).await
+            tokio::time::timeout(Duration::from_secs(60), fetch).await
         };
 
         // Set a maximum time limit for the cache to respond before we forge
@@ -842,7 +842,7 @@ pub enum CacheControl {
 /// Note that when the `TempDir` is dropped it will delete all of its contents
 /// including the path returned.
 pub async fn write_temp_file(
-    pool: &tokio_02::runtime::Handle,
+    pool: &tokio::runtime::Handle,
     path: &Path,
     contents: Vec<u8>,
 ) -> Result<(TempDir, PathBuf)> {
@@ -864,7 +864,7 @@ async fn detect_compiler<T>(
     executable: &Path,
     cwd: &Path,
     env: &[(OsString, OsString)],
-    pool: &tokio_02::runtime::Handle,
+    pool: &tokio::runtime::Handle,
     dist_archive: Option<PathBuf>,
 ) -> Result<(BoxDynCompiler<T>, Option<BoxDynCompilerProxy<T>>)>
 where
@@ -980,7 +980,7 @@ async fn detect_c_compiler<T>(
     creator: T,
     executable: PathBuf,
     env: Vec<(OsString, OsString)>,
-    pool: tokio_02::runtime::Handle,
+    pool: tokio::runtime::Handle,
 ) -> Result<BoxDynCompiler<T>>
 where
     T: CommandCreatorSync,
@@ -1110,7 +1110,7 @@ pub async fn get_compiler_info<T>(
     executable: &Path,
     cwd: &Path,
     env: &[(OsString, OsString)],
-    pool: &tokio_02::runtime::Handle,
+    pool: &tokio::runtime::Handle,
     dist_archive: Option<PathBuf>,
 ) -> Result<(BoxDynCompiler<T>, Option<BoxDynCompilerProxy<T>>)>
 where
@@ -1128,13 +1128,13 @@ mod test {
     use crate::mock_command::*;
     use crate::test::mock_storage::MockStorage;
     use crate::test::utils::*;
-    use futures_03::future::{self, Future};
+    use futures::future::{self, Future};
     use std::fs::{self, File};
     use std::io::Write;
     use std::sync::Arc;
     use std::time::Duration;
     use std::u64;
-    use tokio_02::runtime::Runtime;
+    use tokio::runtime::Runtime;
     use assert_matches::assert_matches;
 
     #[test]

--- a/src/compiler/compiler.rs
+++ b/src/compiler/compiler.rs
@@ -107,7 +107,7 @@ impl CompilerKind {
 
 #[cfg(feature = "dist-client")]
 pub type DistPackagers = (
-    pkg::BoxDynInputsPackager,
+    Box<dyn pkg::InputsPackager>,
     Box<dyn pkg::ToolchainPackager>,
     Box<dyn OutputsRewriter>,
 );
@@ -1866,7 +1866,7 @@ mod test_dist {
             _: JobAlloc,
             _: CompileCommand,
             _: Vec<String>,
-            _: pkg::BoxDynInputsPackager,
+            _: Box<dyn pkg::InputsPackager>,
         ) -> Result<(RunJobResult, PathTransformer)> {
             unreachable!()
         }
@@ -1916,7 +1916,7 @@ mod test_dist {
             _: JobAlloc,
             _: CompileCommand,
             _: Vec<String>,
-            _: pkg::BoxDynInputsPackager,
+            _: Box<dyn pkg::InputsPackager>,
         ) -> Result<(RunJobResult, PathTransformer)> {
             unreachable!()
         }
@@ -1983,7 +1983,7 @@ mod test_dist {
             _: JobAlloc,
             _: CompileCommand,
             _: Vec<String>,
-            _: pkg::BoxDynInputsPackager,
+            _: Box<dyn pkg::InputsPackager>,
         ) -> Result<(RunJobResult, PathTransformer)> {
             unreachable!("fn do_run_job is not used for this test. qed")
         }
@@ -2050,7 +2050,7 @@ mod test_dist {
             job_alloc: JobAlloc,
             command: CompileCommand,
             _: Vec<String>,
-            _: pkg::BoxDynInputsPackager,
+            _: Box<dyn pkg::InputsPackager>,
         ) -> Result<(RunJobResult, PathTransformer)> {
             assert_eq!(job_alloc.job_id, JobId(0));
             assert_eq!(command.executable, "/overridden/compiler");
@@ -2130,7 +2130,7 @@ mod test_dist {
             job_alloc: JobAlloc,
             command: CompileCommand,
             outputs: Vec<String>,
-            inputs_packager: pkg::BoxDynInputsPackager,
+            inputs_packager: Box<dyn pkg::InputsPackager>,
         ) -> Result<(RunJobResult, PathTransformer)> {
             assert_eq!(job_alloc.job_id, JobId(0));
             assert_eq!(command.executable, "/overridden/compiler");

--- a/src/compiler/compiler.rs
+++ b/src/compiler/compiler.rs
@@ -108,7 +108,7 @@ impl CompilerKind {
 #[cfg(feature = "dist-client")]
 pub type DistPackagers = (
     pkg::BoxDynInputsPackager,
-    pkg::BoxDynToolchainPackager,
+    Box<dyn pkg::ToolchainPackager>,
     Box<dyn OutputsRewriter>,
 );
 
@@ -126,7 +126,7 @@ where
     fn kind(&self) -> CompilerKind;
     /// Retrieve a packager
     #[cfg(feature = "dist-client")]
-    fn get_toolchain_packager(&self) -> pkg::BoxDynToolchainPackager;
+    fn get_toolchain_packager(&self) -> Box<dyn pkg::ToolchainPackager>;
     /// Determine whether `arguments` are supported by this compiler.
     fn parse_arguments(
         &self,
@@ -1874,7 +1874,7 @@ mod test_dist {
             &self,
             _: PathBuf,
             _: String,
-            _: pkg::BoxDynToolchainPackager,
+            _: Box<dyn pkg::ToolchainPackager>,
         ) -> Result<(Toolchain, Option<(String, PathBuf)>)> {
             Err(anyhow!("MOCK: put toolchain failure"))
         }
@@ -1924,7 +1924,7 @@ mod test_dist {
             &self,
             _: PathBuf,
             _: String,
-            _: pkg::BoxDynToolchainPackager,
+            _: Box<dyn pkg::ToolchainPackager>,
         ) -> Result<(Toolchain, Option<(String, PathBuf)>)> {
             Ok((self.tc.clone(), None))
         }
@@ -1991,7 +1991,7 @@ mod test_dist {
             &self,
             _: PathBuf,
             _: String,
-            _: pkg::BoxDynToolchainPackager,
+            _: Box<dyn pkg::ToolchainPackager>,
         ) -> Result<(Toolchain, Option<(String, PathBuf)>)> {
             Ok((self.tc.clone(), None))
         }
@@ -2060,7 +2060,7 @@ mod test_dist {
             &self,
             _: PathBuf,
             _: String,
-            _: pkg::BoxDynToolchainPackager,
+            _: Box<dyn pkg::ToolchainPackager>,
         ) -> Result<(Toolchain, Option<(String, PathBuf)>)> {
             Ok((
                 self.tc.clone(),
@@ -2155,7 +2155,7 @@ mod test_dist {
             &self,
             _: PathBuf,
             _: String,
-            _: pkg::BoxDynToolchainPackager,
+            _: Box<dyn pkg::ToolchainPackager>,
         ) -> Result<(Toolchain, Option<(String, PathBuf)>)> {
 
             Ok((

--- a/src/compiler/compiler.rs
+++ b/src/compiler/compiler.rs
@@ -51,7 +51,7 @@ use crate::errors::*;
 
 // only really needed to avoid the hassle of writing it everywhere,
 // since `Compiler<T>: Send` is not enough for rustc
-pub type BoxDynCompiler<T> = Box<dyn Compiler<T> + Send + Sync + 'static>;
+pub type BoxDynCompiler<T> = Box<dyn Compiler<T> + Sync>;
 pub type BoxDynCompilerProxy<T> = Box<dyn CompilerProxy<T> + Send + Sync + 'static>;
 
 /// Can dylibs (shared libraries or proc macros) be distributed on this platform?

--- a/src/compiler/compiler.rs
+++ b/src/compiler/compiler.rs
@@ -51,7 +51,7 @@ use crate::errors::*;
 
 // only really needed to avoid the hassle of writing it everywhere,
 // since `Compiler<T>: Send` is not enough for rustc
-pub type BoxDynCompiler<T> = Box<dyn Compiler<T> + Sync>;
+pub type BoxDynCompiler<T> = Box<dyn Compiler<T>>;
 pub type BoxDynCompilerProxy<T> = Box<dyn CompilerProxy<T> + Send + Sync + 'static>;
 
 /// Can dylibs (shared libraries or proc macros) be distributed on this platform?

--- a/src/compiler/compiler.rs
+++ b/src/compiler/compiler.rs
@@ -190,7 +190,7 @@ where
     #[allow(clippy::too_many_arguments)]
     async fn get_cached_or_compile(
         self: Box<Self>,
-        dist_client: Option<dist::ArcDynClient>,
+        dist_client: Option<Arc<dyn dist::Client>>,
         creator: T,
         storage: Arc<dyn Storage + Send + Sync>,
         arguments: Vec<OsString>,
@@ -397,7 +397,7 @@ where
 
 #[cfg(not(feature = "dist-client"))]
 async fn dist_or_local_compile<T>(
-    _dist_client: Option<dist::ArcDynClient>,
+    _dist_client: Option<Arc<dyn dist::Client>>,
     creator: T,
     _cwd: PathBuf,
     compilation: Box<dyn Compilation>,
@@ -421,7 +421,7 @@ where
 
 #[cfg(feature = "dist-client")]
 async fn dist_or_local_compile<T>(
-    dist_client: Option<dist::ArcDynClient>,
+    dist_client: Option<Arc<dyn dist::Client>>,
     creator: T,
     cwd: PathBuf,
     compilation: Box<dyn Compilation>,
@@ -1845,7 +1845,7 @@ mod test_dist {
     pub struct ErrorPutToolchainClient;
     impl ErrorPutToolchainClient {
         #[allow(clippy::new_ret_no_self)]
-        pub fn new() -> dist::ArcDynClient {
+        pub fn new() -> Arc<dyn dist::Client> {
             Arc::new(ErrorPutToolchainClient)
         }
     }
@@ -1890,7 +1890,7 @@ mod test_dist {
     }
     impl ErrorAllocJobClient {
         #[allow(clippy::new_ret_no_self)]
-        pub fn new() -> dist::ArcDynClient {
+        pub fn new() -> Arc<dyn dist::Client> {
             Arc::new(Self {
                 tc: Toolchain {
                     archive_id: "somearchiveid".to_owned(),
@@ -1941,7 +1941,7 @@ mod test_dist {
     }
     impl ErrorSubmitToolchainClient {
         #[allow(clippy::new_ret_no_self)]
-        pub fn new() -> dist::ArcDynClient {
+        pub fn new() -> Arc<dyn dist::Client> {
             Arc::new(Self {
                 has_started: AtomicBool::default(),
                 tc: Toolchain {
@@ -2008,7 +2008,7 @@ mod test_dist {
     }
     impl ErrorRunJobClient {
         #[allow(clippy::new_ret_no_self)]
-        pub fn new() -> dist::ArcDynClient {
+        pub fn new() -> Arc<dyn dist::Client> {
             Arc::new(Self {
                 has_started: AtomicBool::default(),
                 tc: Toolchain {
@@ -2085,7 +2085,7 @@ mod test_dist {
 
     impl OneshotClient {
         #[allow(clippy::new_ret_no_self)]
-        pub fn new(code: i32, stdout: Vec<u8>, stderr: Vec<u8>) -> dist::ArcDynClient {
+        pub fn new(code: i32, stdout: Vec<u8>, stderr: Vec<u8>) -> Arc<dyn dist::Client> {
             Arc::new(Self {
                 has_started: AtomicBool::default(),
                 tc: Toolchain {

--- a/src/compiler/compiler.rs
+++ b/src/compiler/compiler.rs
@@ -51,7 +51,7 @@ use crate::errors::*;
 
 // only really needed to avoid the hassle of writing it everywhere,
 // since `Compiler<T>: Send` is not enough for rustc
-pub type BoxDynCompilerProxy<T> = Box<dyn CompilerProxy<T> + Send + Sync + 'static>;
+pub type BoxDynCompilerProxy<T> = Box<dyn CompilerProxy<T>>;
 
 /// Can dylibs (shared libraries or proc macros) be distributed on this platform?
 #[cfg(all(feature = "dist-client", target_os = "linux", target_arch = "x86_64"))]

--- a/src/compiler/diab.rs
+++ b/src/compiler/diab.rs
@@ -63,10 +63,7 @@ impl CCompilerImpl for Diab {
     where
         T: CommandCreatorSync,
     {
-        let fut = Box::pin(async move {
-            preprocess(creator, executable, parsed_args, cwd, env_vars, may_dist).await
-        });
-        fut.await
+        preprocess(creator, executable, parsed_args, cwd, env_vars, may_dist).await
     }
 
     fn generate_compile_commands(

--- a/src/compiler/diab.rs
+++ b/src/compiler/diab.rs
@@ -427,7 +427,7 @@ mod test {
     use crate::compiler::*;
     use crate::mock_command::*;
     use crate::test::utils::*;
-    use futures_03::Future;
+    use futures::Future;
     use std::fs::File;
     use std::io::Write;
 

--- a/src/compiler/diab.rs
+++ b/src/compiler/diab.rs
@@ -285,7 +285,6 @@ where
     })
 }
 
-
 pub async fn preprocess<T>(
     creator: &T,
     executable: &Path,

--- a/src/compiler/diab.rs
+++ b/src/compiler/diab.rs
@@ -427,7 +427,6 @@ mod test {
     use crate::compiler::*;
     use crate::mock_command::*;
     use crate::test::utils::*;
-    use futures::Future;
     use std::fs::File;
     use std::io::Write;
 

--- a/src/compiler/gcc.rs
+++ b/src/compiler/gcc.rs
@@ -730,7 +730,6 @@ mod test {
     use crate::compiler::*;
     use crate::mock_command::*;
     use crate::test::utils::*;
-    use futures::Future;
 
     fn parse_arguments_(
         arguments: Vec<String>,

--- a/src/compiler/gcc.rs
+++ b/src/compiler/gcc.rs
@@ -730,7 +730,7 @@ mod test {
     use crate::compiler::*;
     use crate::mock_command::*;
     use crate::test::utils::*;
-    use futures_03::Future;
+    use futures::Future;
 
     fn parse_arguments_(
         arguments: Vec<String>,

--- a/src/compiler/gcc.rs
+++ b/src/compiler/gcc.rs
@@ -63,20 +63,17 @@ impl CCompilerImpl for GCC {
     where
         T: CommandCreatorSync,
     {
-        let fut = async move {
-            preprocess(
-                creator,
-                executable,
-                parsed_args,
-                cwd,
-                env_vars,
-                may_dist,
-                self.kind(),
-                rewrite_includes_only,
-            )
-            .await
-        };
-        fut.await
+        preprocess(
+            creator,
+            executable,
+            parsed_args,
+            cwd,
+            env_vars,
+            may_dist,
+            self.kind(),
+            rewrite_includes_only,
+        )
+        .await
     }
 
     fn generate_compile_commands(

--- a/src/compiler/msvc.rs
+++ b/src/compiler/msvc.rs
@@ -108,7 +108,7 @@ pub async fn detect_showincludes_prefix<T>(
     exe: &OsStr,
     is_clang: bool,
     env: Vec<(OsString, OsString)>,
-    pool: &tokio_02::runtime::Handle,
+    pool: &tokio::runtime::Handle,
 ) -> Result<String>
 where
     T: CommandCreatorSync,
@@ -864,7 +864,7 @@ mod test {
     use crate::env;
     use crate::mock_command::*;
     use crate::test::utils::*;
-    use futures_03::Future;
+    use futures::Future;
 
     fn parse_arguments(arguments: Vec<OsString>) -> CompilerArguments<ParsedArguments> {
         super::parse_arguments(&arguments, &env::current_dir().unwrap(), false)

--- a/src/compiler/msvc.rs
+++ b/src/compiler/msvc.rs
@@ -156,7 +156,6 @@ where
         stdout: stdout_bytes,
         ..
     } = output;
-
     let stdout = from_local_codepage(&stdout_bytes)
         .context("Failed to convert compiler stdout while detecting showIncludes prefix")?;
     for line in stdout.lines() {

--- a/src/compiler/msvc.rs
+++ b/src/compiler/msvc.rs
@@ -19,7 +19,7 @@ use crate::compiler::{
 };
 use crate::dist;
 use crate::mock_command::{CommandCreatorSync, RunCommand};
-use crate::util::{run_input_output, SpawnExt};
+use crate::util::run_input_output;
 use local_encoding::{Encoder, Encoding};
 use log::Level::Debug;
 use std::collections::{HashMap, HashSet};
@@ -864,7 +864,6 @@ mod test {
     use crate::env;
     use crate::mock_command::*;
     use crate::test::utils::*;
-    use futures::Future;
 
     fn parse_arguments(arguments: Vec<OsString>) -> CompilerArguments<ParsedArguments> {
         super::parse_arguments(&arguments, &env::current_dir().unwrap(), false)

--- a/src/compiler/msvc.rs
+++ b/src/compiler/msvc.rs
@@ -70,19 +70,16 @@ impl CCompilerImpl for MSVC {
     where
         T: CommandCreatorSync,
     {
-        let fut = Box::pin(async move {
-            preprocess(
-                creator,
-                executable,
-                parsed_args,
-                cwd,
-                env_vars,
-                may_dist,
-                &self.includes_prefix,
-            )
-            .await
-        });
-        fut.await
+        preprocess(
+            creator,
+            executable,
+            parsed_args,
+            cwd,
+            env_vars,
+            may_dist,
+            &self.includes_prefix,
+        )
+        .await
     }
 
     fn generate_compile_commands(

--- a/src/compiler/nvcc.rs
+++ b/src/compiler/nvcc.rs
@@ -132,6 +132,9 @@ impl CCompilerImpl for NVCC {
         if !parsed_args.dependency_args.is_empty() {
             let first = run_input_output(dep_before_preprocessor(), None);
             let second = run_input_output(cmd, None);
+            // TODO: If we need to chain these to emulate a frontend, shouldn't
+            // we explicitly wait on the first one before starting the second one?
+            // (rather than via which drives these concurrently)
             let (_f, s) = futures::future::try_join(first, second).await?;
             Ok(s)
         } else {

--- a/src/compiler/nvcc.rs
+++ b/src/compiler/nvcc.rs
@@ -130,14 +130,12 @@ impl CCompilerImpl for NVCC {
         //Need to chain the dependency generation and the preprocessor
         //to emulate a `proper` front end
         if !parsed_args.dependency_args.is_empty() {
-            let first =
-                Box::pin(async move { run_input_output(dep_before_preprocessor(), None).await });
-            let second = Box::pin(async move { run_input_output(cmd, None).await });
-            let (_f, s) = futures::try_join!(first, second)?;
+            let first = run_input_output(dep_before_preprocessor(), None);
+            let second = run_input_output(cmd, None);
+            let (_f, s) = futures::future::try_join(first, second).await?;
             Ok(s)
         } else {
-            let fut = Box::pin(async move { run_input_output(cmd, None).await });
-            fut.await
+            run_input_output(cmd, None).await
         }
     }
 

--- a/src/compiler/nvcc.rs
+++ b/src/compiler/nvcc.rs
@@ -21,7 +21,7 @@ use crate::compiler::{gcc, write_temp_file, Cacheable, CompileCommand, CompilerA
 use crate::dist;
 use crate::mock_command::{CommandCreator, CommandCreatorSync, RunCommand};
 use crate::util::{run_input_output, OsStrExt};
-use futures_03::future::{self, Future};
+use futures::future::{self, Future};
 use log::Level::Trace;
 use std::ffi::OsString;
 use std::fs::File;
@@ -133,7 +133,7 @@ impl CCompilerImpl for NVCC {
             let first =
                 Box::pin(async move { run_input_output(dep_before_preprocessor(), None).await });
             let second = Box::pin(async move { run_input_output(cmd, None).await });
-            let (_f, s) = futures_03::try_join!(first, second)?;
+            let (_f, s) = futures::try_join!(first, second)?;
             Ok(s)
         } else {
             let fut = Box::pin(async move { run_input_output(cmd, None).await });
@@ -209,7 +209,7 @@ mod test {
     use crate::compiler::*;
     use crate::mock_command::*;
     use crate::test::utils::*;
-    use futures_03::Future;
+    use futures::Future;
     use std::collections::HashMap;
     use std::path::PathBuf;
 

--- a/src/compiler/nvcc.rs
+++ b/src/compiler/nvcc.rs
@@ -21,10 +21,10 @@ use crate::compiler::{gcc, write_temp_file, Cacheable, CompileCommand, CompilerA
 use crate::dist;
 use crate::mock_command::{CommandCreator, CommandCreatorSync, RunCommand};
 use crate::util::{run_input_output, OsStrExt};
-use futures::future::{self, Future};
 use log::Level::Trace;
 use std::ffi::OsString;
 use std::fs::File;
+use std::future::Future;
 use std::io::{self, Write};
 use std::path::{Path, PathBuf};
 use std::process;
@@ -209,7 +209,6 @@ mod test {
     use crate::compiler::*;
     use crate::mock_command::*;
     use crate::test::utils::*;
-    use futures::Future;
     use std::collections::HashMap;
     use std::path::PathBuf;
 

--- a/src/compiler/rust.rs
+++ b/src/compiler/rust.rs
@@ -15,7 +15,7 @@
 use crate::compiler::args::*;
 use crate::compiler::{
     Cacheable, ColorMode, Compilation, CompileCommand, Compiler, CompilerArguments, CompilerHasher,
-    CompilerKind, CompilerProxy, HashResult, BoxDynCompilerProxy,
+    CompilerKind, CompilerProxy, HashResult
 };
 #[cfg(feature = "dist-client")]
 use crate::compiler::{DistPackagers, OutputsRewriter};
@@ -543,7 +543,7 @@ where
         })
     }
 
-    fn box_clone(&self) -> BoxDynCompilerProxy<T> {
+    fn box_clone(&self) -> Box<dyn CompilerProxy<T>> {
         Box::new((*self).clone())
     }
 }

--- a/src/compiler/rust.rs
+++ b/src/compiler/rust.rs
@@ -24,7 +24,7 @@ use crate::dist;
 use crate::dist::pkg;
 use crate::mock_command::{CommandCreatorSync, RunCommand};
 use crate::util::{fmt_duration_as_secs, hash_all, run_input_output, Digest};
-use crate::util::{ref_env, HashToDigest, OsStrExt, SpawnExt};
+use crate::util::{ref_env, HashToDigest, OsStrExt};
 use filetime::FileTime;
 use log::Level::Trace;
 #[cfg(feature = "dist-client")]

--- a/src/compiler/rust.rs
+++ b/src/compiler/rust.rs
@@ -452,7 +452,7 @@ where
         CompilerKind::Rust
     }
     #[cfg(feature = "dist-client")]
-    fn get_toolchain_packager(&self) -> pkg::BoxDynToolchainPackager {
+    fn get_toolchain_packager(&self) -> Box<dyn pkg::ToolchainPackager> {
         Box::new(RustToolchainPackager {
             sysroot: self.sysroot.clone(),
         })

--- a/src/compiler/rust.rs
+++ b/src/compiler/rust.rs
@@ -202,7 +202,7 @@ async fn get_source_files<T>(
     arguments: &[OsString],
     cwd: &Path,
     env_vars: &[(OsString, OsString)],
-    pool: &tokio_02::runtime::Handle,
+    pool: &tokio::runtime::Handle,
 ) -> Result<Vec<PathBuf>>
 where
     T: CommandCreatorSync,
@@ -352,7 +352,7 @@ impl Rust {
         env_vars: &[(OsString, OsString)],
         rustc_verbose_version: &str,
         dist_archive: Option<PathBuf>,
-        pool: tokio_02::runtime::Handle,
+        pool: tokio::runtime::Handle,
     ) -> Result<Rust>
     where
         T: CommandCreatorSync,
@@ -414,7 +414,7 @@ impl Rust {
             };
 
             let (sysroot_and_libs, rlib_dep_reader) =
-                futures_03::join!(sysroot_and_libs, rlib_dep_reader);
+                futures::join!(sysroot_and_libs, rlib_dep_reader);
 
             let (sysroot, libs) = sysroot_and_libs.context("Determining sysroot + libs failed")?;
 
@@ -1214,7 +1214,7 @@ where
         cwd: PathBuf,
         env_vars: Vec<(OsString, OsString)>,
         _may_dist: bool,
-        pool: &tokio_02::runtime::Handle,
+        pool: &tokio::runtime::Handle,
         _rewrite_includes_only: bool,
     ) -> Result<HashResult> {
         let RustHasher {
@@ -1298,7 +1298,7 @@ where
         // pin_mut!(staticlib_hashes);
         // pin_mut!(extern_hashes);
         let (source_files_and_hashes, extern_hashes, staticlib_hashes) =
-            futures_03::join!(source_files_and_hashes, extern_hashes, staticlib_hashes);
+            futures::join!(source_files_and_hashes, extern_hashes, staticlib_hashes);
 
 
         let (source_files, source_hashes) = source_files_and_hashes?;

--- a/src/compiler/rust.rs
+++ b/src/compiler/rust.rs
@@ -398,7 +398,7 @@ impl Rust {
                 libs.push(path);
             };
             libs.sort();
-            Ok((sysroot, libs))
+            Result::Ok((sysroot, libs))
         };
 
         #[cfg(feature = "dist-client")]

--- a/src/compiler/rust.rs
+++ b/src/compiler/rust.rs
@@ -15,7 +15,7 @@
 use crate::compiler::args::*;
 use crate::compiler::{
     Cacheable, ColorMode, Compilation, CompileCommand, Compiler, CompilerArguments, CompilerHasher,
-    CompilerKind, CompilerProxy, HashResult, BoxDynCompilerProxy, BoxDynCompiler,
+    CompilerKind, CompilerProxy, HashResult, BoxDynCompilerProxy,
 };
 #[cfg(feature = "dist-client")]
 use crate::compiler::{DistPackagers, OutputsRewriter};
@@ -490,7 +490,7 @@ where
         }
     }
 
-    fn box_clone(&self) -> BoxDynCompiler<T> {
+    fn box_clone(&self) -> Box<dyn Compiler<T>> {
         Box::new((*self).clone())
     }
 }

--- a/src/dist/cache.rs
+++ b/src/dist/cache.rs
@@ -15,7 +15,7 @@ use std::io::Read;
 #[cfg(feature = "dist-client")]
 mod client {
     use crate::config;
-    use crate::dist::pkg::BoxDynToolchainPackager;
+    use crate::dist::pkg::ToolchainPackager;
     use crate::dist::Toolchain;
     use anyhow::{bail, Context, Error, Result};
     use lru_disk_cache::Error as LruError;
@@ -180,7 +180,7 @@ mod client {
             &self,
             compiler_path: PathBuf,
             weak_key: String,
-            toolchain_packager: BoxDynToolchainPackager,
+            toolchain_packager: Box<dyn ToolchainPackager>,
         ) -> Result<(Toolchain, Option<(String, PathBuf)>)> {
             if self.disabled_toolchains.contains(&compiler_path) {
                 bail!(

--- a/src/dist/cache.rs
+++ b/src/dist/cache.rs
@@ -280,8 +280,9 @@ mod client {
     #[cfg(test)]
     mod test {
         use crate::config;
-        use crate::test::utils::*;
+        use crate::test::utils::create_file;
         use std::io::Write;
+
         use super::ClientToolchains;
 
         struct PanicToolchainPackager;

--- a/src/dist/client_auth.rs
+++ b/src/dist/client_auth.rs
@@ -1,5 +1,5 @@
-use futures_03::channel::oneshot;
-use futures_03::task as task_03;
+use futures::channel::oneshot;
+use futures::task as task_03;
 use http::StatusCode;
 use hyper::server::conn::AddrIncoming;
 use hyper::service::Service;
@@ -15,7 +15,7 @@ use std::pin::Pin;
 use std::result;
 use std::sync::mpsc;
 use std::time::Duration;
-use tokio_02::runtime::Runtime;
+use tokio::runtime::Runtime;
 use url::Url;
 use uuid::Uuid;
 
@@ -37,7 +37,7 @@ trait ServeFn:
         Box<
             dyn 'static
                 + Send
-                + futures_03::Future<Output = result::Result<Response<Body>, hyper::Error>>,
+                + futures::Future<Output = result::Result<Response<Body>, hyper::Error>>,
         >,
     > + Send
     + 'static
@@ -54,7 +54,7 @@ impl<T> ServeFn for T where
             Box<
                 dyn 'static
                     + Send
-                    + futures_03::Future<Output = result::Result<Response<Body>, hyper::Error>>,
+                    + futures::Future<Output = result::Result<Response<Body>, hyper::Error>>,
             >,
         >
 {
@@ -122,7 +122,7 @@ mod code_grant_pkce {
         html_response, json_response, query_pairs, MIN_TOKEN_VALIDITY, MIN_TOKEN_VALIDITY_WARNING,
         REDIRECT_WITH_AUTH_JSON,
     };
-    use futures_03::channel::oneshot;
+    use futures::channel::oneshot;
     use hyper::{Body, Method, Request, Response, StatusCode};
     use rand::RngCore;
     use sha2::{Digest, Sha256};
@@ -276,7 +276,7 @@ mod code_grant_pkce {
             Box<
                 dyn 'static
                     + Send
-                    + futures_03::Future<Output = result::Result<Self::Response, Self::Error>>,
+                    + futures::Future<Output = result::Result<Self::Response, Self::Error>>,
             >,
         >;
 
@@ -345,7 +345,7 @@ mod implicit {
         html_response, json_response, query_pairs, MIN_TOKEN_VALIDITY, MIN_TOKEN_VALIDITY_WARNING,
         REDIRECT_WITH_AUTH_JSON,
     };
-    use futures_03::channel::oneshot;
+    use futures::channel::oneshot;
     use hyper::{Body, Method, Request, Response, StatusCode};
     use std::collections::HashMap;
     use std::sync::mpsc;
@@ -498,7 +498,7 @@ mod implicit {
             Box<
                 dyn 'static
                     + Send
-                    + futures_03::Future<Output = result::Result<Self::Response, Self::Error>>,
+                    + futures::Future<Output = result::Result<Self::Response, Self::Error>>,
             >,
         >;
 
@@ -554,7 +554,7 @@ trait Servix:
             Box<
                 dyn 'static
                     + Send
-                    + futures_03::Future<Output = result::Result<Response<Body>, hyper::Error>>,
+                    + futures::Future<Output = result::Result<Response<Body>, hyper::Error>>,
             >,
         >,
     >
@@ -572,7 +572,7 @@ impl<T> Servix for T where
                 Box<
                     dyn 'static
                         + Send
-                        + futures_03::Future<Output = result::Result<Response<Body>, hyper::Error>>,
+                        + futures::Future<Output = result::Result<Response<Body>, hyper::Error>>,
                 >,
             >,
         >
@@ -587,7 +587,7 @@ trait MkSr<S>:
         Response = S,
         Error = hyper::Error,
         Future = Pin<
-            Box<dyn 'static + Send + futures_03::Future<Output = result::Result<S, hyper::Error>>>,
+            Box<dyn 'static + Send + futures::Future<Output = result::Result<S, hyper::Error>>>,
         >,
     >
 where
@@ -608,7 +608,7 @@ where
                 Box<
                     dyn 'static
                         + Send
-                        + futures_03::Future<Output = result::Result<S, hyper::Error>>,
+                        + futures::Future<Output = result::Result<S, hyper::Error>>,
                 >,
             >,
         >,
@@ -622,7 +622,7 @@ trait SpawnerFn<S>:
     + for<'t> FnOnce(
         &'t AddrStream,
     ) -> Pin<
-        Box<dyn 'static + Send + futures_03::Future<Output = result::Result<S, hyper::Error>>>,
+        Box<dyn 'static + Send + futures::Future<Output = result::Result<S, hyper::Error>>>,
     >
 where
     S: Servix,
@@ -638,7 +638,7 @@ where
         + for<'t> FnOnce(
             &'t AddrStream,
         ) -> Pin<
-            Box<dyn 'static + Send + futures_03::Future<Output = result::Result<S, hyper::Error>>>,
+            Box<dyn 'static + Send + futures::Future<Output = result::Result<S, hyper::Error>>>,
         >,
 {
 }
@@ -669,7 +669,7 @@ impl<'t, S: Servix, C: SpawnerFn<S>> Service<&'t AddrStream> for ServiceSpawner<
         Box<
             dyn 'static
                 + Send
-                + futures_03::Future<Output = result::Result<Self::Response, Self::Error>>,
+                + futures::Future<Output = result::Result<Self::Response, Self::Error>>,
         >,
     >;
 
@@ -738,7 +738,7 @@ pub fn get_token_oauth2_code_grant_pkce(
         let f = Box::pin(async move { Ok(CodeGrant) });
         f as Pin<
             Box<
-                dyn futures_03::Future<Output = std::result::Result<CodeGrant, hyper::Error>>
+                dyn futures::Future<Output = std::result::Result<CodeGrant, hyper::Error>>
                     + std::marker::Send
                     + 'static,
             >,
@@ -807,7 +807,7 @@ pub fn get_token_oauth2_implicit(client_id: &str, mut auth_url: Url) -> Result<S
         let f = Box::pin(async move { Ok(Implicit) });
         f as Pin<
             Box<
-                dyn futures_03::Future<Output = std::result::Result<Implicit, hyper::Error>>
+                dyn futures::Future<Output = std::result::Result<Implicit, hyper::Error>>
                     + std::marker::Send
                     + 'static,
             >,

--- a/src/dist/http.rs
+++ b/src/dist/http.rs
@@ -1078,7 +1078,7 @@ mod server {
 mod client {
     use super::super::cache;
     use crate::config;
-    use crate::dist::pkg::{BoxDynInputsPackager, ToolchainPackager};
+    use crate::dist::pkg::{InputsPackager, ToolchainPackager};
     use crate::dist::{
         self, AllocJobResult, CompileCommand, JobAlloc, PathTransformer, RunJobResult,
         SchedulerStatusResult, SubmitToolchainResult, Toolchain,
@@ -1284,7 +1284,7 @@ mod client {
             job_alloc: JobAlloc,
             command: CompileCommand,
             outputs: Vec<String>,
-            inputs_packager: BoxDynInputsPackager,
+            inputs_packager: Box<dyn InputsPackager>,
         ) -> Result<(RunJobResult, PathTransformer)> {
             let url = urls::server_run_job(job_alloc.server_id, job_alloc.job_id);
             let mut req = self.client.lock().unwrap().post(url);

--- a/src/dist/http.rs
+++ b/src/dist/http.rs
@@ -1114,14 +1114,14 @@ mod client {
         // and only support owned bytes, which means the whole toolchain would end up in memory
         client: Arc<Mutex<reqwest::blocking::Client>>,
         client_async: Arc<Mutex<reqwest::Client>>,
-        pool: tokio_02::runtime::Handle,
+        pool: tokio::runtime::Handle,
         tc_cache: Arc<cache::ClientToolchains>,
         rewrite_includes_only: bool,
     }
 
     impl Client {
         pub fn new(
-            pool: &tokio_02::runtime::Handle,
+            pool: &tokio::runtime::Handle,
             scheduler_url: reqwest::Url,
             cache_dir: &Path,
             cache_size: u64,

--- a/src/dist/http.rs
+++ b/src/dist/http.rs
@@ -1078,7 +1078,7 @@ mod server {
 mod client {
     use super::super::cache;
     use crate::config;
-    use crate::dist::pkg::{BoxDynInputsPackager, BoxDynToolchainPackager, };
+    use crate::dist::pkg::{BoxDynInputsPackager, ToolchainPackager};
     use crate::dist::{
         self, AllocJobResult, CompileCommand, JobAlloc, PathTransformer, RunJobResult,
         SchedulerStatusResult, SubmitToolchainResult, Toolchain,
@@ -1324,7 +1324,7 @@ mod client {
             &self,
             compiler_path: PathBuf,
             weak_key: String,
-            toolchain_packager: BoxDynToolchainPackager,
+            toolchain_packager: Box<dyn ToolchainPackager>,
         ) -> Result<(Toolchain, Option<(String, PathBuf)>)> {
             let compiler_path = compiler_path.to_owned();
             let weak_key = weak_key.to_owned();

--- a/src/dist/mod.rs
+++ b/src/dist/mod.rs
@@ -13,7 +13,7 @@
 // limitations under the License.
 
 use crate::compiler;
-use pkg::{BoxDynInputsPackager, BoxDynToolchainPackager};
+use pkg::{BoxDynInputsPackager, ToolchainPackager};
 use rand::{rngs::OsRng, RngCore};
 use std::ffi::OsString;
 use std::fmt;
@@ -741,7 +741,7 @@ pub trait Client: Send {
         &self,
         compiler_path: PathBuf,
         weak_key: String,
-        toolchain_packager: BoxDynToolchainPackager,
+        toolchain_packager: Box<dyn ToolchainPackager>,
     ) -> Result<(Toolchain, Option<(String, PathBuf)>)>;
     fn rewrite_includes_only(&self) -> bool;
     fn get_custom_toolchain(&self, exe: &PathBuf) -> Option<PathBuf>;

--- a/src/dist/mod.rs
+++ b/src/dist/mod.rs
@@ -20,7 +20,6 @@ use std::io::{self, Read};
 use std::net::SocketAddr;
 use std::path::PathBuf;
 use std::process;
-use std::sync::Arc;
 use std::str::FromStr;
 #[cfg(feature = "dist-server")]
 use std::sync::Mutex;
@@ -711,11 +710,8 @@ pub trait BuilderIncoming: Send + Sync {
 }
 
 /////////
-
-pub type ArcDynClient = Arc<dyn Client + Send + Sync + 'static>;
-
 #[async_trait::async_trait]
-pub trait Client: Send {
+pub trait Client: Send + Sync {
     // To Scheduler
     async fn do_alloc_job(&self, tc: Toolchain) -> Result<AllocJobResult>;
     // To Scheduler

--- a/src/dist/mod.rs
+++ b/src/dist/mod.rs
@@ -14,7 +14,7 @@
 
 use crate::compiler;
 use pkg::{BoxDynInputsPackager, BoxDynToolchainPackager};
-use rand::RngCore;
+use rand::{rngs::OsRng, RngCore};
 use std::ffi::OsString;
 use std::fmt;
 use std::io::{self, Read};
@@ -374,8 +374,8 @@ impl FromStr for ServerId {
 #[serde(deny_unknown_fields)]
 pub struct ServerNonce(u64);
 impl ServerNonce {
-    pub fn from_rng(rng: &mut rand::rngs::OsRng) -> Self {
-        ServerNonce(rng.next_u64())
+    pub fn new() -> Self {
+        ServerNonce(OsRng.next_u64())
     }
 }
 

--- a/src/dist/mod.rs
+++ b/src/dist/mod.rs
@@ -13,7 +13,6 @@
 // limitations under the License.
 
 use crate::compiler;
-use pkg::{BoxDynInputsPackager, ToolchainPackager};
 use rand::{rngs::OsRng, RngCore};
 use std::ffi::OsString;
 use std::fmt;
@@ -50,9 +49,7 @@ pub mod pkg;
 #[cfg(not(feature = "dist-client"))]
 mod pkg {
     pub trait ToolchainPackager {}
-    pub type BoxDynToolchainPackager = Box<dyn ToolchainPackager>;
     pub trait InputsPackager {}
-    pub type BoxDynInputsPackager = Box<dyn InputsPackager>;
 }
 
 #[cfg(target_os = "windows")]
@@ -735,13 +732,13 @@ pub trait Client: Send {
         job_alloc: JobAlloc,
         command: CompileCommand,
         outputs: Vec<String>,
-        inputs_packager: BoxDynInputsPackager,
+        inputs_packager: Box<dyn pkg::InputsPackager>,
     ) -> Result<(RunJobResult, PathTransformer)>;
     async fn put_toolchain(
         &self,
         compiler_path: PathBuf,
         weak_key: String,
-        toolchain_packager: Box<dyn ToolchainPackager>,
+        toolchain_packager: Box<dyn pkg::ToolchainPackager>,
     ) -> Result<(Toolchain, Option<(String, PathBuf)>)>;
     fn rewrite_includes_only(&self) -> bool;
     fn get_custom_toolchain(&self, exe: &PathBuf) -> Option<PathBuf>;

--- a/src/dist/pkg.rs
+++ b/src/dist/pkg.rs
@@ -26,8 +26,6 @@ pub trait ToolchainPackager: Send {
     fn write_pkg(self: Box<Self>, f: fs::File) -> Result<()>;
 }
 
-pub type BoxDynInputsPackager = Box<dyn InputsPackager + Send + 'static>;
-
 pub trait InputsPackager: Send {
     fn write_inputs(self: Box<Self>, wtr: &mut dyn io::Write) -> Result<dist::PathTransformer>;
 }

--- a/src/dist/pkg.rs
+++ b/src/dist/pkg.rs
@@ -22,8 +22,6 @@ use crate::errors::*;
 
 pub use self::toolchain_imp::*;
 
-pub type BoxDynToolchainPackager = Box<dyn ToolchainPackager + Send + 'static>;
-
 pub trait ToolchainPackager: Send {
     fn write_pkg(self: Box<Self>, f: fs::File) -> Result<()>;
 }

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -13,7 +13,6 @@
 // limitations under the License.
 
 pub use anyhow::{anyhow, bail, Context, Error};
-use std::boxed::Box;
 use std::process;
 
 // We use `anyhow` for error handling.

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -13,8 +13,6 @@
 // limitations under the License.
 
 pub use anyhow::{anyhow, bail, Context, Error};
-use futures::future as legacy_future;
-use futures::Future as LegacyFuture;
 use std::boxed::Box;
 use std::process;
 

--- a/src/jobserver.rs
+++ b/src/jobserver.rs
@@ -4,7 +4,7 @@ use std::process::Command as StdCommand;
 
 use futures::channel::mpsc;
 use futures::channel::oneshot;
-use futures::prelude::*;
+use futures::StreamExt;
 
 use crate::errors::*;
 

--- a/src/jobserver.rs
+++ b/src/jobserver.rs
@@ -2,9 +2,9 @@ use std::io;
 use std::sync::Arc;
 use std::process::Command as StdCommand;
 
-use futures_03::channel::mpsc;
-use futures_03::channel::oneshot;
-use futures_03::prelude::*;
+use futures::channel::mpsc;
+use futures::channel::oneshot;
+use futures::prelude::*;
 
 use crate::errors::*;
 
@@ -41,7 +41,7 @@ impl Client {
             let helper = inner
                 .clone()
                 .into_helper_thread(move |token| {
-                    tokio_02::runtime::Runtime::new()
+                    tokio::runtime::Runtime::new()
                         .unwrap()
                         .block_on(async {
                             if let Some(sender) = rx.next().await {

--- a/src/mock_command.rs
+++ b/src/mock_command.rs
@@ -55,8 +55,8 @@ use std::path::Path;
 use std::process::{ExitStatus, Output, Stdio};
 use std::result;
 use std::sync::{Arc, Mutex};
-use tokio_02::io::{AsyncRead, AsyncWrite};
-use tokio_02::process::{ChildStderr, ChildStdin, ChildStdout};
+use tokio::io::{AsyncRead, AsyncWrite};
+use tokio::process::{ChildStderr, ChildStdin, ChildStdout};
 use std::process::Command as StdCommand;
 
 /// A trait that provides a subset of the methods of `std::process::Child`.
@@ -144,7 +144,7 @@ pub trait CommandCreatorSync: Clone + Send + Sync + 'static {
 }
 
 pub struct Child {
-    inner: tokio_02::process::Child,
+    inner: tokio::process::Child,
     token: Acquired,
 }
 
@@ -272,7 +272,7 @@ impl RunCommand for AsyncCommand {
         self.jobserver.configure(&mut inner);
 
         let token = self.jobserver.acquire().await?;
-        let mut inner = tokio_02::process::Command::from(inner);
+        let mut inner = tokio::process::Command::from(inner);
         let child = inner
             .spawn()
             .with_context(|| format!("failed to spawn {:?}", inner))?;
@@ -558,7 +558,7 @@ mod test {
     use super::*;
     use crate::jobserver::Client;
     use crate::test::utils::*;
-    use futures_03::Future;
+    use futures::Future;
     use std::ffi::OsStr;
     use std::io;
     use std::process::{ExitStatus, Output};

--- a/src/mock_command.rs
+++ b/src/mock_command.rs
@@ -558,7 +558,6 @@ mod test {
     use super::*;
     use crate::jobserver::Client;
     use crate::test::utils::*;
-    use futures::Future;
     use std::ffi::OsStr;
     use std::io;
     use std::process::{ExitStatus, Output};

--- a/src/server.rs
+++ b/src/server.rs
@@ -16,7 +16,7 @@
 #![allow(deprecated)]
 #![allow(clippy::complexity)]
 
-use crate::cache::{storage_from_config, ArcDynStorage};
+use crate::cache::{storage_from_config, Storage};
 use crate::compiler::{
     get_compiler_info, CacheControl, CompileResult, Compiler, CompilerArguments, CompilerHasher,
     CompilerKind, CompilerProxy, DistType, MissType,
@@ -464,7 +464,7 @@ impl<C: CommandCreatorSync> SccacheServer<C> {
         mut runtime: Runtime,
         client: Client,
         dist_client: DistClientContainer,
-        storage: ArcDynStorage,
+        storage: Arc<dyn Storage + Send + Sync>,
     ) -> Result<SccacheServer<C>> {
         let addr = SocketAddrV4::new(Ipv4Addr::new(127, 0, 0, 1), port);
         let listener = runtime.block_on(TcpListener::bind(&SocketAddr::V4(addr)))?;
@@ -494,7 +494,7 @@ impl<C: CommandCreatorSync> SccacheServer<C> {
 
     /// Set the storage this server will use.
     #[allow(dead_code)]
-    pub fn set_storage(&mut self, storage: ArcDynStorage) {
+    pub fn set_storage(&mut self, storage: Arc<dyn Storage + Send + Sync>) {
         self.service.storage = storage;
     }
 
@@ -654,7 +654,7 @@ struct SccacheService<C> where C: Send {
     dist_client: Arc<DistClientContainer>,
 
     /// Cache storage.
-    storage: ArcDynStorage,
+    storage: Arc<dyn Storage + Send + Sync>,
 
     /// A cache of known compiler info.
     compilers: Arc<RwLock<CompilerMap<C>>>,
@@ -784,7 +784,7 @@ where
 {
     pub fn new(
         dist_client: DistClientContainer,
-        storage: ArcDynStorage,
+        storage: Arc<dyn Storage + Send + Sync>,
         client: &Client,
         rt: tokio::runtime::Handle,
         tx: mpsc::Sender<ServerMessage>,

--- a/src/server.rs
+++ b/src/server.rs
@@ -991,7 +991,7 @@ where
                     .await;
 
                 let (c, proxy) = match info {
-                    Ok((ref c, ref proxy)) => (c.clone(), proxy.as_ref().map(|p| p.box_clone())),
+                    Ok((c, proxy)) => (c.clone(), proxy.clone()),
                     Err(err) => {
                         trace!("Inserting PLAIN cache map info for {:?}", &path);
                         me.compilers.write().await.insert(path, None);

--- a/src/server.rs
+++ b/src/server.rs
@@ -163,7 +163,7 @@ struct DistClientConfig {
 #[cfg(feature = "dist-client")]
 enum DistClientState {
     #[cfg(feature = "dist-client")]
-    Some(Box<DistClientConfig>, dist::ArcDynClient),
+    Some(Box<DistClientConfig>, Arc<dyn dist::Client>),
     #[cfg(feature = "dist-client")]
     FailWithMessage(Box<DistClientConfig>, String),
     #[cfg(feature = "dist-client")]
@@ -191,7 +191,7 @@ impl DistClientContainer {
         DistInfo::Disabled("dist-client feature not selected".to_string())
     }
 
-    fn get_client(&self) -> Result<Option<dist::ArcDynClient>> {
+    fn get_client(&self) -> Result<Option<Arc<dyn dist::Client>>> {
         Ok(None)
     }
 }
@@ -273,7 +273,7 @@ impl DistClientContainer {
         }))
     }
 
-    fn get_client(&self) -> Result<Option<dist::ArcDynClient>> {
+    fn get_client(&self) -> Result<Option<Arc<dyn dist::Client>>> {
         let mut guard = self.state.lock();
         let state = guard.as_mut().unwrap();
         let state: &mut DistClientState = &mut **state;

--- a/src/server.rs
+++ b/src/server.rs
@@ -613,7 +613,7 @@ impl<C: CommandCreatorSync> SccacheServer<C> {
 }
 
 /// maps a compiler proxy path to a compiler proxy and it's last modification time
-type CompilerProxyMap<C> = HashMap<PathBuf, (Box<dyn CompilerProxy<C> + Send + 'static>, FileTime)>;
+type CompilerProxyMap<C> = HashMap<PathBuf, (Box<dyn CompilerProxy<C>>, FileTime)>;
 
 /// maps a compiler path to a compiler cache entry
 type CompilerMap<C> = HashMap<PathBuf, Option<CompilerCacheEntry<C>>>;

--- a/src/server.rs
+++ b/src/server.rs
@@ -20,7 +20,6 @@ use crate::cache::{storage_from_config, Storage};
 use crate::compiler::{
     get_compiler_info, CacheControl, CompileResult, Compiler, CompilerArguments, CompilerHasher,
     CompilerKind, CompilerProxy, DistType, MissType,
-    BoxDynCompiler,
 };
 #[cfg(feature = "dist-client")]
 use crate::config;
@@ -896,7 +895,7 @@ where
         path: PathBuf,
         cwd: PathBuf,
         env: &[(OsString, OsString)],
-    ) -> Result<BoxDynCompiler<C>> {
+    ) -> Result<Box<dyn Compiler<C>>> {
         trace!("compiler_info");
 
         let me = self.clone();
@@ -1034,7 +1033,7 @@ where
     /// If so, run `start_compile_task` to execute it.
     async fn check_compiler(
         &self,
-        compiler: Result<BoxDynCompiler<C>>,
+        compiler: Result<Box<dyn Compiler<C>>>,
         cmd: Vec<OsString>,
         cwd: PathBuf,
         env_vars: Vec<(OsString, OsString)>,
@@ -1090,7 +1089,7 @@ where
     /// the result in the cache.
     fn start_compile_task(
         &self,
-        compiler: BoxDynCompiler<C>,
+        compiler: Box<dyn Compiler<C>>,
         hasher: Box<dyn CompilerHasher<C>>,
         arguments: Vec<OsString>,
         cwd: PathBuf,

--- a/src/server.rs
+++ b/src/server.rs
@@ -42,6 +42,7 @@ use std::collections::HashMap;
 use std::env;
 use std::ffi::{OsStr, OsString};
 use std::fs::metadata;
+use std::future::Future;
 use std::io::{self, Write};
 use std::marker::Unpin;
 #[cfg(feature = "dist-client")]
@@ -519,7 +520,7 @@ impl<C: CommandCreatorSync> SccacheServer<C> {
     /// long anyway.
     pub fn run<F>(self, shutdown: F) -> io::Result<()>
     where
-        F: futures::Future + Send + 'static,
+        F: Future + Send + 'static,
         C: Send,
     {
         let SccacheServer {

--- a/src/server.rs
+++ b/src/server.rs
@@ -623,7 +623,7 @@ type CompilerMap<C> = HashMap<PathBuf, Option<CompilerCacheEntry<C>>>;
 /// entry of the compiler cache
 struct CompilerCacheEntry<C> {
     /// compiler argument trait obj
-    pub compiler: Box<dyn Compiler<C> + Send + 'static>,
+    pub compiler: Box<dyn Compiler<C> + 'static>,
     /// modification time of the compilers executable file
     pub mtime: FileTime,
     /// distributed compilation extra info
@@ -633,7 +633,7 @@ struct CompilerCacheEntry<C> {
 impl<C> CompilerCacheEntry<C>
 {
     fn new(
-        compiler: Box<dyn Compiler<C> + Send + 'static>,
+        compiler: Box<dyn Compiler<C> + 'static>,
         mtime: FileTime,
         dist_info: Option<(PathBuf, FileTime)>,
     ) -> Self {

--- a/src/server.rs
+++ b/src/server.rs
@@ -31,6 +31,7 @@ use crate::jobserver::Client;
 use crate::mock_command::{CommandCreatorSync, ProcessCommandCreator};
 use crate::protocol::{Compile, CompileFinished, CompileResponse, Request, Response};
 use crate::util;
+#[cfg(feature = "dist-client")]
 use anyhow::Context as _;
 use bytes::{buf::ext::BufMutExt, Bytes, BytesMut};
 use filetime::FileTime;
@@ -56,6 +57,7 @@ use std::sync::Arc;
 use std::sync::Mutex;
 use std::task::{Context, Poll, Waker};
 use std::time::Duration;
+#[cfg(feature = "dist-client")]
 use std::time::Instant;
 use std::u64;
 use tokio::{

--- a/src/server.rs
+++ b/src/server.rs
@@ -189,7 +189,7 @@ impl DistClientContainer {
 
     pub fn reset_state(&self) {}
 
-    pub fn get_status(&self) -> DistInfo {
+    pub async fn get_status(&self) -> DistInfo {
         DistInfo::Disabled("dist-client feature not selected".to_string())
     }
 

--- a/src/test/mock_storage.rs
+++ b/src/test/mock_storage.rs
@@ -19,7 +19,6 @@ use futures_locks::Mutex;
 use std::time::Duration;
 use std::sync::Arc;
 
-
 /// A mock `Storage` implementation.
 pub struct MockStorage {
     rx: Arc<Mutex<mpsc::UnboundedReceiver<Result<Cache>>>>,

--- a/src/test/mock_storage.rs
+++ b/src/test/mock_storage.rs
@@ -14,7 +14,8 @@
 
 use crate::cache::{Cache, CacheWrite, Storage};
 use crate::errors::*;
-use futures::{channel::mpsc::{self, UnboundedReceiver, UnboundedSender}, future::{self, Future}, pin_mut};
+use futures::channel::mpsc::{self, UnboundedReceiver, UnboundedSender};
+use std::future::Future;
 use std::time::Duration;
 use std::sync::{Arc, Mutex};
 use core::pin::Pin;

--- a/src/test/mock_storage.rs
+++ b/src/test/mock_storage.rs
@@ -14,7 +14,7 @@
 
 use crate::cache::{Cache, CacheWrite, Storage};
 use crate::errors::*;
-use futures_03::{channel::mpsc::{self, UnboundedReceiver, UnboundedSender}, future::{self, Future}, pin_mut};
+use futures::{channel::mpsc::{self, UnboundedReceiver, UnboundedSender}, future::{self, Future}, pin_mut};
 use std::time::Duration;
 use std::sync::{Arc, Mutex};
 use core::pin::Pin;

--- a/src/test/tests.rs
+++ b/src/test/tests.rs
@@ -19,8 +19,7 @@ use crate::jobserver::Client;
 use crate::mock_command::*;
 use crate::server::{DistClientContainer, SccacheServer, ServerMessage};
 use crate::test::utils::*;
-use futures_03::channel::oneshot::{self, Sender};
-use futures_03::compat::*;
+use futures::channel::oneshot::{self, Sender};
 use std::fs::File;
 use std::io::{Cursor, Write};
 #[cfg(not(target_os = "macos"))]
@@ -32,7 +31,7 @@ use std::sync::{mpsc, Arc, Mutex};
 use std::thread;
 use std::time::Duration;
 use std::u64;
-use tokio_02::runtime::Runtime;
+use tokio::runtime::Runtime;
 
 /// Options for running the server in tests.
 #[derive(Default)]

--- a/src/test/tests.rs
+++ b/src/test/tests.rs
@@ -169,7 +169,7 @@ fn test_server_unsupported_compiler() {
         let mut c = server_creator.lock().unwrap();
         // The server will check the compiler, so pretend to be an unsupported
         // compiler.
-        c.next_command_spawns(Ok(MockChild::new(exit_status(0), "hello", "💥")));
+        c.next_command_spawns(Ok(MockChild::new(exit_status(0), "hello", "error")));
     }
     // Ask the server to compile something.
     //TODO: MockCommand should validate these!
@@ -197,7 +197,7 @@ fn test_server_unsupported_compiler() {
     );
     match res {
         Ok(_) => panic!("do_compile should have failed!"),
-        Err(e) => assert_eq!("Compiler not supported: \"💥\"", e.to_string()),
+        Err(e) => assert_eq!("Compiler not supported: \"error\"", e.to_string()),
     }
     // Make sure we ran the mock processes.
     assert_eq!(0, server_creator.lock().unwrap().children.len());

--- a/src/test/utils.rs
+++ b/src/test/utils.rs
@@ -225,8 +225,8 @@ impl TestFixture {
     }
 }
 
-pub fn single_threaded_runtime() -> tokio_02::runtime::Runtime {
-    tokio_02::runtime::Builder::new()
+pub fn single_threaded_runtime() -> tokio::runtime::Runtime {
+    tokio::runtime::Builder::new()
         .enable_all()
         .basic_scheduler()
         .core_threads(1)
@@ -234,7 +234,7 @@ pub fn single_threaded_runtime() -> tokio_02::runtime::Runtime {
         .unwrap()
 }
 
-/// An add on trait, to allow calling `.wait()` for `futures_03::Future`
+/// An add on trait, to allow calling `.wait()` for `futures::Future`
 /// as it was possible for `futures` at `0.1`.
 ///
 /// Intended for test only!
@@ -242,23 +242,23 @@ pub(crate) trait Waiter<R> {
     fn wait(self) -> R;
 }
 
-impl<T,O> Waiter<O> for T where T: futures_03::Future<Output=O> {
+impl<T,O> Waiter<O> for T where T: futures::Future<Output=O> {
     fn wait(self) -> O
     {
-        let mut rt = tokio_02::runtime::Runtime::new().unwrap();
+        let mut rt = tokio::runtime::Runtime::new().unwrap();
         rt.block_on(self)
     }
 }
 
 /// Helper to avoid issues with mock implementations.
-pub(crate) fn fut_wrap<V>(val: V) -> impl futures_03::Future<Output=V> {
+pub(crate) fn fut_wrap<V>(val: V) -> impl futures::Future<Output=V> {
     async move {
         val
     }
 }
 
 /// Helper to avoid issues with mock implementations.
-pub(crate) fn fut_unreachable<V>(txt: &'static str) -> impl futures_03::Future<Output=V> {
+pub(crate) fn fut_unreachable<V>(txt: &'static str) -> impl futures::Future<Output=V> {
     async move {
         unreachable!(txt)
     }

--- a/src/test/utils.rs
+++ b/src/test/utils.rs
@@ -247,7 +247,7 @@ pub(crate) trait Waiter<R> {
 #[cfg(test)]
 impl<T, O> Waiter<O> for T where T: Future<Output=O> {
     fn wait(self) -> O {
-        let mut rt = tokio::runtime::Runtime::new().unwrap();
+        let mut rt = single_threaded_runtime();
         rt.block_on(self)
     }
 }

--- a/src/test/utils.rs
+++ b/src/test/utils.rs
@@ -14,7 +14,6 @@
 
 use crate::mock_command::*;
 use std::collections::HashMap;
-use std::convert::TryFrom;
 use std::env;
 use std::ffi::OsString;
 use std::fs::{self, File};

--- a/src/test/utils.rs
+++ b/src/test/utils.rs
@@ -18,6 +18,7 @@ use std::convert::TryFrom;
 use std::env;
 use std::ffi::OsString;
 use std::fs::{self, File};
+use std::future::Future;
 use std::io;
 use std::path::{Path, PathBuf};
 
@@ -238,29 +239,16 @@ pub fn single_threaded_runtime() -> tokio::runtime::Runtime {
 /// as it was possible for `futures` at `0.1`.
 ///
 /// Intended for test only!
+#[cfg(test)]
 pub(crate) trait Waiter<R> {
     fn wait(self) -> R;
 }
 
-impl<T,O> Waiter<O> for T where T: futures::Future<Output=O> {
-    fn wait(self) -> O
-    {
+#[cfg(test)]
+impl<T, O> Waiter<O> for T where T: Future<Output=O> {
+    fn wait(self) -> O {
         let mut rt = tokio::runtime::Runtime::new().unwrap();
         rt.block_on(self)
-    }
-}
-
-/// Helper to avoid issues with mock implementations.
-pub(crate) fn fut_wrap<V>(val: V) -> impl futures::Future<Output=V> {
-    async move {
-        val
-    }
-}
-
-/// Helper to avoid issues with mock implementations.
-pub(crate) fn fut_unreachable<V>(txt: &'static str) -> impl futures::Future<Output=V> {
-    async move {
-        unreachable!(txt)
     }
 }
 

--- a/src/util.rs
+++ b/src/util.rs
@@ -27,11 +27,6 @@ use std::time::Duration;
 
 use crate::errors::*;
 
-#[derive(Debug, thiserror::Error)]
-pub enum UtilError {
-    #[error(transparent)]
-    Spawn(ProcessError),
-}
 
 #[derive(Clone)]
 pub struct Digest {
@@ -364,7 +359,6 @@ pub fn ref_env(env: &[(OsString, OsString)]) -> impl Iterator<Item = (&OsString,
 #[cfg(feature = "hyperx")]
 pub use self::http_extension::{HeadersExt, RequestExt};
 
-// TODO delete all of it
 #[cfg(feature = "hyperx")]
 mod http_extension {
     use reqwest::header::{HeaderMap, HeaderValue};

--- a/src/util.rs
+++ b/src/util.rs
@@ -15,10 +15,10 @@
 use crate::mock_command::{CommandChild, RunCommand};
 use blake3::Hasher as blake3_Hasher;
 use byteorder::{BigEndian, ByteOrder};
-pub(crate) use futures::task::SpawnExt;
 use serde::Serialize;
 use std::ffi::{OsStr, OsString};
 use std::fs::File;
+use std::future::Future;
 use std::hash::Hasher;
 use std::io::prelude::*;
 use std::path::{Path, PathBuf};
@@ -166,9 +166,9 @@ where
                     .await
                     .context("failed to read stdout")?;
                 Ok(Some(buf))
-            }) as Pin<Box<dyn futures::Future<Output=Result<Option<Vec<u8>>>> + Send>>
+            }) as Pin<Box<dyn Future<Output=Result<Option<Vec<u8>>>> + Send>>
         })
-        .unwrap_or_else(|| Box::pin(async move { Ok(None) }) as Pin<Box<dyn futures::Future<Output=Result<Option<Vec<u8>>>> + Send>> );
+        .unwrap_or_else(|| Box::pin(async move { Ok(None) }) as Pin<Box<dyn Future<Output=Result<Option<Vec<u8>>>> + Send>> );
 
     let stderr = child
         .take_stderr()
@@ -179,10 +179,10 @@ where
                     .await
                     .context("failed to read stderr")?;
                 Ok(Some(buf))
-            })  as Pin<Box<dyn futures::Future<Output=Result<Option<Vec<u8>>>> + Send>>
+            })  as Pin<Box<dyn Future<Output=Result<Option<Vec<u8>>>> + Send>>
         })
         .unwrap_or_else(|| {
-            Box::pin(async move { Ok(None)  })  as Pin<Box<dyn futures::Future<Output=Result<Option<Vec<u8>>>> + Send>>
+            Box::pin(async move { Ok(None) }) as Pin<Box<dyn Future<Output=Result<Option<Vec<u8>>>> + Send>>
 
         });
 

--- a/tests/harness/mod.rs
+++ b/tests/harness/mod.rs
@@ -296,7 +296,7 @@ impl DistSystem {
         wait_for_http(scheduler_url, Duration::from_millis(100), MAX_STARTUP_WAIT);
         wait_for(
             || {
-                let mut runtime = tokio_02::runtime::Runtime::new().unwrap();
+                let mut runtime = tokio::runtime::Runtime::new().unwrap();
                 let status = runtime.block_on (async { self.scheduler_status().await });
                 if matches!(status, SchedulerStatusResult { num_servers: 0, num_cpus: _, in_progress: 0 })
                 {
@@ -431,7 +431,7 @@ impl DistSystem {
         wait_for_http(url, Duration::from_millis(100), MAX_STARTUP_WAIT);
         wait_for(
             || {
-                let mut rt = tokio_02::runtime::Runtime::new().unwrap();
+                let mut rt = tokio::runtime::Runtime::new().unwrap();
                 let status = rt.block_on(async { self.scheduler_status().await });
                 if matches!(status, SchedulerStatusResult { num_servers: 1, num_cpus: _, in_progress: 0 })
                 {


### PR DESCRIPTION
This contains further tweaks to the future migration PR. While the first few commits should be more or less constrained to this PR, the further I went later on (specifically in https://github.com/paritytech/sccache/commit/f9f9ddeb3b3980fe3b0fe959ace611038aed4eb0) the more I also adapted almost all of the existing files to further restrain the final diff with the mozilla/master branch. I'll split that commit into part that only touches code related to this PR (I didn't notice how divergent our forks are now) but I'm opening it now to get some more feedback on the related parts.

The only thing that's left is to
- probably prune/adapt the pure Rust openssl-like dependencies in `src/dist/http.rs` and
- implement remaining TODOs in rusoto/S3-related code since there are a lot of those there and I'm not sure in how good of a mergeable state that's in for upstream to consider it

and we should have a change set, provided that we cherry-pick/synchronize the main branch with upstream, that should be more or less minimal (as much as migrating everywhere as pervasive code as futures can be considered minimal). Changes that simply move stuff around were done to minimize the diff with `mozilla/master` so it might be helpful to separately open a diff view between that and this PR.