### PR TITLE
Fix the CI

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -2,7 +2,6 @@
 #
 # sccache
 
-
 stages:
   - check
   - test
@@ -12,6 +11,7 @@ variables:
   GIT_STRATEGY:                    fetch
   GIT_DEPTH:                       100
   CARGO_INCREMENTAL:               0
+  RUST_BACKTRACE:                  1
   # this var is changed to "-:staging" when the CI image gets rebuilt
   # read more https://github.com/paritytech/scripts/pull/244
   CI_IMAGE:                        "paritytech/sccache-ci-ubuntu:staging" # temporary override
@@ -76,19 +76,29 @@ nightly-test:
   <<:                              *docker-env
   stage:                           test
   variables:
-    EXTRA_FEATURES:                "unstable"
+    FEATURES:                      "unstable"
   script:
     - cargo +nightly build --verbose --features="${EXTRA_FEATURES}" || exit 1
-    - RUST_BACKTRACE=1 cargo +nightly test --workspace --verbose --features="${EXTRA_FEATURES}"
+    - cargo +nightly test --workspace --verbose --features="${EXTRA_FEATURES}"
 
 stable-test:
+  <<:                              *docker-env
   stage:                           test
+  variables:
+    EXTRA_FEATURES:                ""
+  script:
+    - cargo +stable build --verbose --features="${EXTRA_FEATURES}" || exit 1
+    - cargo +stable test --workspace --verbose --features="${EXTRA_FEATURES}"
+
+# For now simply collect artifacts
+artifacts:
   <<:                              *docker-env
   <<:                              *collect-artifacts
+  stage:                           deploy
+  variables:
+    EXTRA_FEATURES:                "dist-client,dist-server"
   script:
-    - cargo +stable build --verbose
-    - RUST_BACKTRACE=1 cargo +stable test --workspace --verbose
-    - cargo +stable build --release --features="dist-client,dist-server"
+    - cargo +stable build --release --features="${EXTRA_FEATURES}"
     # collect artifacts
     - mkdir -p ./artifacts/sccache/
     - mv ./target/release/sccache ./artifacts/sccache/.

--- a/tests/sccache_cargo.rs
+++ b/tests/sccache_cargo.rs
@@ -42,6 +42,7 @@ fn test_rust_cargo_cmd(cmd: &str) {
     use assert_cmd::prelude::*;
     use predicates::prelude::*;
     use std::env;
+    use std::ffi::OsStr;
     use std::fs;
     use std::path::Path;
     use std::process::{Command, Stdio};
@@ -86,8 +87,11 @@ fn test_rust_cargo_cmd(cmd: &str) {
         .success();
     // `cargo clean` first, just to be sure there's no leftover build objects.
     let envs = vec![
-        ("RUSTC_WRAPPER", &sccache),
-        ("CARGO_TARGET_DIR", &cargo_dir),
+        ("RUSTC_WRAPPER", sccache.as_ref()),
+        ("CARGO_TARGET_DIR", cargo_dir.as_ref()),
+        // Explicitly disable incremental compilation because sccache is unable
+        // to cache it at the time of writing.
+        ("CARGO_INCREMENTAL", OsStr::new("0")),
     ];
     Command::new(&cargo)
         .args(&["clean"])
@@ -118,14 +122,13 @@ fn test_rust_cargo_cmd(cmd: &str) {
         .stderr(predicates::str::contains("\x1b[").from_utf8())
         .success();
     // Now get the stats and ensure that we had a cache hit for the second build.
-    // Ideally we'd check the stats more usefully here--the test crate has one dependency (itoa)
-    // so there are two separate compilations, but cargo will build the test crate with
-    // incremental compilation enabled, so sccache will not cache it.
+    // The test crate has one dependency (itoa) so there are two separate
+    // compilations.
     trace!("sccache --show-stats");
     sccache_command()
         .args(&["--show-stats", "--stats-format=json"])
         .assert()
-        .stdout(predicates::str::contains(r#""cache_hits":{"counts":{"Rust":1}}"#).from_utf8())
+        .stdout(predicates::str::contains(r#""cache_hits":{"counts":{"Rust":2}}"#).from_utf8())
         .success();
     stop();
 }

--- a/tests/system.rs
+++ b/tests/system.rs
@@ -116,9 +116,9 @@ fn test_basic_compile(compiler: Compiler, tempdir: &Path) {
     get_stats(|info| {
         assert_eq!(1, info.stats.compile_requests);
         assert_eq!(1, info.stats.requests_executed);
-        assert_eq!(1, info.stats.cache_hits.all());
-        assert_eq!(0, info.stats.cache_misses.all());
-        assert_eq!(None, info.stats.cache_misses.get("C/C++"));
+        assert_eq!(0, info.stats.cache_hits.all());
+        assert_eq!(1, info.stats.cache_misses.all());
+        assert_eq!(&1, info.stats.cache_misses.get("C/C++").unwrap());
     });
     trace!("compile");
     fs::remove_file(&out_file).unwrap();
@@ -133,10 +133,10 @@ fn test_basic_compile(compiler: Compiler, tempdir: &Path) {
     get_stats(|info| {
         assert_eq!(2, info.stats.compile_requests);
         assert_eq!(2, info.stats.requests_executed);
-        assert_eq!(2, info.stats.cache_hits.all());
-        assert_eq!(0, info.stats.cache_misses.all());
-        assert_eq!(&2, info.stats.cache_hits.get("C/C++").unwrap());
-        assert_eq!(None, info.stats.cache_misses.get("C/C++"));
+        assert_eq!(1, info.stats.cache_hits.all());
+        assert_eq!(1, info.stats.cache_misses.all());
+        assert_eq!(&1, info.stats.cache_hits.get("C/C++").unwrap());
+        assert_eq!(&1, info.stats.cache_misses.get("C/C++").unwrap());
     });
 }
 
@@ -257,9 +257,9 @@ int main(int argc, char** argv) {
         .assert()
         .success();
     get_stats(|info| {
-        assert_eq!(1, info.stats.cache_hits.all());
-        assert_eq!(0, info.stats.cache_misses.all());
-        assert_eq!(None, info.stats.cache_misses.get("C/C++"));
+        assert_eq!(0, info.stats.cache_hits.all());
+        assert_eq!(1, info.stats.cache_misses.all());
+        assert_eq!(&1, info.stats.cache_misses.get("C/C++").unwrap());
     });
     // Compile the same source again to ensure we can get a cache hit.
     trace!("compile source.c (2)");
@@ -270,15 +270,14 @@ int main(int argc, char** argv) {
         .assert()
         .success();
     get_stats(|info| {
-        assert_eq!(2, info.stats.cache_hits.all());
-        assert_eq!(0, info.stats.cache_misses.all());
-        assert_eq!(&2, info.stats.cache_hits.get("C/C++").unwrap());
-        assert_eq!(None, info.stats.cache_misses.get("C/C++"));
+        assert_eq!(1, info.stats.cache_hits.all());
+        assert_eq!(1, info.stats.cache_misses.all());
+        assert_eq!(&1, info.stats.cache_hits.get("C/C++").unwrap());
+        assert_eq!(&1, info.stats.cache_misses.get("C/C++").unwrap());
     });
     // Now write out a slightly different source file that will preprocess to the same thing,
     // modulo line numbers. This should not be a cache hit because line numbers are important
-    // with -fprofile-generate. But that behaviour changed at some point
-    // before gcc 10.2.1 and now it produces a cache hit.
+    // with -fprofile-generate.
     write_source(
         &tempdir,
         SRC,
@@ -297,32 +296,14 @@ int main(int argc, char** argv) {
     sccache_command()
         .args(&args)
         .current_dir(tempdir)
-        .envs(env_vars.clone())
-        .assert()
-        .success();
-    get_stats(|info| {
-        assert_eq!(3, info.stats.cache_hits.all());
-        assert_eq!(0, info.stats.cache_misses.all());
-        assert_eq!(&3, info.stats.cache_hits.get("C/C++").unwrap());
-        assert_eq!(None, info.stats.cache_misses.get("C/C++"));
-    });
-
-    // Now doing the same again with `UNDEFINED` defined
-    // should produce a cache hit too, after preproc
-    // it's still the same source file
-    args.extend(vec_from!(OsString, "-DUNDEFINED"));
-    trace!("compile source.c (4)");
-    sccache_command()
-        .args(&args)
-        .current_dir(tempdir)
         .envs(env_vars)
         .assert()
         .success();
     get_stats(|info| {
-        assert_eq!(4, info.stats.cache_hits.all());
-        assert_eq!(0, info.stats.cache_misses.all());
-        assert_eq!(&4, info.stats.cache_hits.get("C/C++").unwrap());
-        assert_eq!(None, info.stats.cache_misses.get("C/C++"));
+        assert_eq!(1, info.stats.cache_hits.all());
+        assert_eq!(2, info.stats.cache_misses.all());
+        assert_eq!(&1, info.stats.cache_hits.get("C/C++").unwrap());
+        assert_eq!(&2, info.stats.cache_misses.get("C/C++").unwrap());
     });
 }
 

--- a/tests/system.rs
+++ b/tests/system.rs
@@ -150,7 +150,7 @@ fn test_noncacheable_stats(compiler: Compiler, tempdir: &Path) {
     copy_to_tempdir(&[INPUT], tempdir);
 
     trace!("compile");
-    Command::new(assert_cmd::cargo::cargo_bin(env!("CARGO_PKG_NAME")))
+    sccache_command()
         .arg(&exe)
         .arg("-E")
         .arg(INPUT)


### PR DESCRIPTION
This syncs some of the previously failing code to what upstream has, for simplicity, and basically applies https://github.com/mozilla/sccache/pull/983.

There were two instances of environment-specific issues here:
1. Our CI runs with `CARGO_INCREMENTAL=0`, which was inherited in one run and resulted in a cache hit - the reason for that being sccache being unable to cache incremental-enabled compilation, which is the default in Rust now (which we opted out of). Instead, on a test level, we explicitly disable it ourselves making it environment-agnostic.
2. Our CI runs with `SCCACHE_REDIS` set, presumably to speed up all of our general compilation. However, the configuration for sccache is merged, in general, from the environment variables (such as `SCCACHE_REDIS`) and the configuration files. The test code tried to override the env var responsible for pointing to the configuration file, however other env vars were still taken into account when running the test code. Because the configuration was merged, we probably had cache hits in our Docker-connected Redis cache instance rather than relying only on test-local disk cache. To work around that, we attempt to prune any sccache-related environments from the sccache test invocation, rather than only overriding `SCCACHE_CONF` et al.

With this, the tests are now passing :tada: Only clippy fails now, but that's to be fixed in a follow-up PR.