### PR TITLE
dist: Replace openssl with pure Rust libraries for cert generation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -131,6 +131,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "assert_matches"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9b34d609dfbaf33d6889b2b7106d3ca345eacad44200913df5ba02bfd31d2ba9"
+
+[[package]]
 name = "async-channel"
 version = "1.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2878,6 +2884,7 @@ dependencies = [
  "anyhow",
  "ar",
  "assert_cmd",
+ "assert_matches",
  "async-trait",
  "atty",
  "base64 0.13.0",
@@ -2919,7 +2926,6 @@ dependencies = [
  "parity-tokio-ipc",
  "percent-encoding 2.1.0",
  "picky",
- "picky-asn1-x509",
  "predicates",
  "rand 0.8.3",
  "redis",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -16,6 +16,60 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ee2a4ec343196209d6594e19543ae87a39f96d5534d7174822a3ad825dd6ed7e"
 
 [[package]]
+name = "aead"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7fc95d1bdb8e6666b2b217308eeeb09f2d6728d104be3e31916cc74d15420331"
+dependencies = [
+ "generic-array",
+]
+
+[[package]]
+name = "aes"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f7001367fde4c768a19d1029f0a8be5abd9308e1119846d5bd9ad26297b8faf5"
+dependencies = [
+ "aes-soft",
+ "aesni",
+ "block-cipher",
+]
+
+[[package]]
+name = "aes-gcm"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "86f5007801316299f922a6198d1d09a0bae95786815d066d5880d13f7c45ead1"
+dependencies = [
+ "aead",
+ "aes",
+ "block-cipher",
+ "ghash",
+ "subtle",
+]
+
+[[package]]
+name = "aes-soft"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4925647ee64e5056cf231608957ce7c81e12d6d6e316b9ce1404778cc1d35fa7"
+dependencies = [
+ "block-cipher",
+ "byteorder",
+ "opaque-debug 0.2.3",
+]
+
+[[package]]
+name = "aesni"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d050d39b0b7688b3a3254394c3e30a9d66c41dcf9b05b0e2dbdc623f6505d264"
+dependencies = [
+ "block-cipher",
+ "opaque-debug 0.2.3",
+]
+
+[[package]]
 name = "aho-corasick"
 version = "0.7.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -273,6 +327,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "bit-vec"
+version = "0.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "349f9b6a179ed607305526ca489b34ad0a41aed5f7980fa90eb03160b69598fb"
+
+[[package]]
 name = "bitflags"
 version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -310,8 +370,24 @@ version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4152116fd6e9dadb291ae18fc1ec3575ed6d84c29642d97890f4b4a3417297e4"
 dependencies = [
+ "block-padding",
  "generic-array",
 ]
+
+[[package]]
+name = "block-cipher"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fa136449e765dc7faa244561ccae839c394048667929af599b5d931ebe7b7f10"
+dependencies = [
+ "generic-array",
+]
+
+[[package]]
+name = "block-padding"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8d696c370c750c948ada61c69a0ee2cbbb9c50b1019ddb86d9317157a99c2cae"
 
 [[package]]
 name = "blocking"
@@ -548,6 +624,12 @@ name = "cpuid-bool"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8aebca1129a03dc6dc2b127edd729435bbc4a37e1d5f4d7513165089ceb02634"
+
+[[package]]
+name = "cpuid-bool"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dcb25d077389e53838a8158c8e99174c5a9d902dee4904320db714f3c653ffba"
 
 [[package]]
 name = "crc32fast"
@@ -1032,6 +1114,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "ghash"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "97304e4cd182c3846f7575ced3890c53012ce534ad9114046b0a9e00bb30a375"
+dependencies = [
+ "opaque-debug 0.3.0",
+ "polyval",
+]
+
+[[package]]
 name = "gimli"
 version = "0.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1388,8 +1480,14 @@ dependencies = [
  "ring",
  "serde",
  "serde_json",
- "simple_asn1",
+ "simple_asn1 0.4.1",
 ]
+
+[[package]]
+name = "keccak"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "67c21572b4949434e4fc1e1978b99c5f77064153c59d998bf13ecd96fb5ecba7"
 
 [[package]]
 name = "kernel32-sys"
@@ -1421,12 +1519,21 @@ name = "lazy_static"
 version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
+dependencies = [
+ "spin",
+]
 
 [[package]]
 name = "libc"
 version = "0.2.82"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "89203f3fba0a3795506acaad8ebce3c80c0af93f994d5a1d7a0b1eeb23271929"
+
+[[package]]
+name = "libm"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c7d73b3f436185384286bd8098d17ec07c9a7d2388a6599f824d8502b529702a"
 
 [[package]]
 name = "libmount"
@@ -1503,7 +1610,7 @@ checksum = "7b5a279bb9607f9f53c22d496eade00d138d1bdcccd07d74650387cf94942a15"
 dependencies = [
  "block-buffer",
  "digest",
- "opaque-debug",
+ "opaque-debug 0.3.0",
 ]
 
 [[package]]
@@ -1753,12 +1860,53 @@ dependencies = [
 ]
 
 [[package]]
+name = "num-bigint"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4e0d047c1062aa51e256408c560894e5251f08925980e53cf1aa5bd00eec6512"
+dependencies = [
+ "autocfg 1.0.1",
+ "num-integer",
+ "num-traits",
+]
+
+[[package]]
+name = "num-bigint-dig"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5d51546d704f52ef14b3c962b5776e53d5b862e5790e40a350d366c209bd7f7a"
+dependencies = [
+ "autocfg 0.1.7",
+ "byteorder",
+ "lazy_static",
+ "libm",
+ "num-integer",
+ "num-iter",
+ "num-traits",
+ "rand 0.7.3",
+ "serde",
+ "smallvec 1.6.1",
+ "zeroize",
+]
+
+[[package]]
 name = "num-integer"
 version = "0.1.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d2cc698a63b549a70bc047073d2949cce27cd1c7b0a4a862d08a8031bc2801db"
 dependencies = [
  "autocfg 1.0.1",
+ "num-traits",
+]
+
+[[package]]
+name = "num-iter"
+version = "0.1.42"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b2021c8337a54d21aca0d59a92577a029af9431cb59b909b03252b9c164fad59"
+dependencies = [
+ "autocfg 1.0.1",
+ "num-integer",
  "num-traits",
 ]
 
@@ -1794,10 +1942,25 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8d3b63360ec3cb337817c2dbd47ab4a0f170d285d8e5a2064600f3def1402397"
 
 [[package]]
+name = "oid"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "293d5f18898078ea69ba1c84f3688d1f2b6744df8211da36197153157cee7055"
+dependencies = [
+ "serde",
+]
+
+[[package]]
 name = "once_cell"
 version = "1.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "13bd41f508810a131401606d54ac32a467c97172d74ba7662562ebba5ad07fa0"
+
+[[package]]
+name = "opaque-debug"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2839e79665f131bdb5782e51f2c6c9599c133c6098982a54c794358bf432529c"
 
 [[package]]
 name = "opaque-debug"
@@ -1882,7 +2045,7 @@ dependencies = [
  "libc",
  "redox_syscall",
  "rustc_version",
- "smallvec",
+ "smallvec 0.6.13",
  "winapi 0.3.9",
 ]
 
@@ -1946,6 +2109,67 @@ checksum = "234f71a15de2288bcb7e3b6515828d22af7ec8598ee6d24c3b526fa0a80b67a0"
 dependencies = [
  "siphasher",
  "unicase 1.4.2",
+]
+
+[[package]]
+name = "picky"
+version = "6.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4d3c0575d4f2163ffd3e23992ed7f4fa304304c49fe2c22ce20b1b694437f0c4"
+dependencies = [
+ "aes-gcm",
+ "base64 0.12.3",
+ "digest",
+ "http 0.2.4",
+ "num-bigint-dig",
+ "oid",
+ "picky-asn1",
+ "picky-asn1-der",
+ "picky-asn1-x509",
+ "rand 0.7.3",
+ "rsa",
+ "serde",
+ "serde_json",
+ "sha-1",
+ "sha2",
+ "sha3",
+ "thiserror",
+]
+
+[[package]]
+name = "picky-asn1"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "90e3f783e3e499bdb8e66d2a48c9da561fc369f96853eb83fb31e28931e4a492"
+dependencies = [
+ "oid",
+ "serde",
+ "serde_bytes",
+]
+
+[[package]]
+name = "picky-asn1-der"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "233e556fc14cd42f38290ecd53f23a9fe047df2837d3d7494d27872b40a64bca"
+dependencies = [
+ "picky-asn1",
+ "serde",
+ "serde_bytes",
+]
+
+[[package]]
+name = "picky-asn1-x509"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7c40870d0d056271c2976f7c1747b1df4332f979ab78634574ef5b534e6b0f0f"
+dependencies = [
+ "base64 0.12.3",
+ "num-bigint-dig",
+ "oid",
+ "picky-asn1",
+ "picky-asn1-der",
+ "serde",
 ]
 
 [[package]]
@@ -2023,6 +2247,17 @@ dependencies = [
  "log 0.4.11",
  "wepoll-sys",
  "winapi 0.3.9",
+]
+
+[[package]]
+name = "polyval"
+version = "0.4.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eebcc4aa140b9abd2bc40d9c3f7ccec842679cd79045ac3a7ac698c1a064b7cd"
+dependencies = [
+ "cpuid-bool 0.2.0",
+ "opaque-debug 0.3.0",
+ "universal-hash",
 ]
 
 [[package]]
@@ -2483,6 +2718,67 @@ dependencies = [
 ]
 
 [[package]]
+name = "rsa"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3648b669b10afeab18972c105e284a7b953a669b0be3514c27f9b17acab2f9cd"
+dependencies = [
+ "byteorder",
+ "digest",
+ "lazy_static",
+ "num-bigint-dig",
+ "num-integer",
+ "num-iter",
+ "num-traits",
+ "pem",
+ "rand 0.7.3",
+ "sha2",
+ "simple_asn1 0.4.1",
+ "subtle",
+ "thiserror",
+ "zeroize",
+]
+
+[[package]]
+name = "rsa-der"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1170c86c683547fa781a0e39e6e281ebaedd4515be8a806022984f427ea3d44d"
+dependencies = [
+ "simple_asn1 0.4.1",
+]
+
+[[package]]
+name = "rsa-export"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a29a64b407c67f1f7a605538dc0975d40f5f1479fc1b04f7568c78120993f7f7"
+dependencies = [
+ "num-bigint-dig",
+ "num-integer",
+ "pem",
+ "rsa",
+ "simple_asn1 0.5.2",
+]
+
+[[package]]
+name = "rsa-pem"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3ee7d87640dab9972e4d05503aad4c30a107ca50912d10596d44f8555b7da4ce"
+dependencies = [
+ "bit-vec",
+ "log 0.4.11",
+ "num-bigint 0.2.6",
+ "num-bigint-dig",
+ "num-traits",
+ "pem",
+ "rsa",
+ "thiserror",
+ "yasna",
+]
+
+[[package]]
 name = "rust-argon2"
 version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2577,6 +2873,8 @@ dependencies = [
  "openssl",
  "parity-tokio-ipc",
  "percent-encoding 2.1.0",
+ "picky",
+ "picky-asn1-x509",
  "predicates",
  "rand 0.7.3",
  "redis",
@@ -2585,6 +2883,10 @@ dependencies = [
  "retry",
  "ring",
  "rouille",
+ "rsa",
+ "rsa-der",
+ "rsa-export",
+ "rsa-pem",
  "selenium-rs",
  "serde",
  "serde_derive",
@@ -2689,6 +2991,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_bytes"
+version = "0.11.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "16ae07dd2f88a366f15bd0632ba725227018c69a1c8550a927324f8eb8368bb9"
+dependencies = [
+ "serde",
+]
+
+[[package]]
 name = "serde_derive"
 version = "1.0.118"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2742,9 +3053,9 @@ checksum = "ce3cdf1b5e620a498ee6f2a171885ac7e22f0e12089ec4b3d22b84921792507c"
 dependencies = [
  "block-buffer",
  "cfg-if 1.0.0",
- "cpuid-bool",
+ "cpuid-bool 0.1.2",
  "digest",
- "opaque-debug",
+ "opaque-debug 0.3.0",
 ]
 
 [[package]]
@@ -2761,9 +3072,21 @@ checksum = "6e7aab86fe2149bad8c507606bdb3f4ef5e7b2380eb92350f56122cca72a42a8"
 dependencies = [
  "block-buffer",
  "cfg-if 1.0.0",
- "cpuid-bool",
+ "cpuid-bool 0.1.2",
  "digest",
- "opaque-debug",
+ "opaque-debug 0.3.0",
+]
+
+[[package]]
+name = "sha3"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f81199417d4e5de3f04b1e871023acea7389672c4135918f05aa9cbf2f2fa809"
+dependencies = [
+ "block-buffer",
+ "digest",
+ "keccak",
+ "opaque-debug 0.3.0",
 ]
 
 [[package]]
@@ -2782,8 +3105,20 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "692ca13de57ce0613a363c8c2f1de925adebc81b04c923ac60c5488bb44abe4b"
 dependencies = [
  "chrono",
- "num-bigint",
+ "num-bigint 0.2.6",
  "num-traits",
+]
+
+[[package]]
+name = "simple_asn1"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6e0e9076e5242ff5a58e854cb478ea9caebce01088f86d3d9c6ad336b7655263"
+dependencies = [
+ "chrono",
+ "num-bigint 0.4.0",
+ "num-traits",
+ "thiserror",
 ]
 
 [[package]]
@@ -2816,6 +3151,12 @@ checksum = "f7b0758c52e15a8b5e3691eae6cc559f08eee9406e548a4477ba4e67770a82b6"
 dependencies = [
  "maybe-uninit",
 ]
+
+[[package]]
+name = "smallvec"
+version = "1.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fe0f37c9e8f3c5a4a66ad655a93c74daac4ad00c441533bf5c6e7990bb42604e"
 
 [[package]]
 name = "socket2"
@@ -3514,6 +3855,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f7fe0bb3479651439c9112f72b6c505038574c9fbb575ed1bf3b797fa39dd564"
 
 [[package]]
+name = "universal-hash"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8326b2c654932e3e4f9196e69d08fdf7cfd718e1dc6f66b347e6024a0c961402"
+dependencies = [
+ "generic-array",
+ "subtle",
+]
+
+[[package]]
 name = "unix_socket"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3861,6 +4212,37 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "244c3741f4240ef46274860397c7c74e50eb23624996930e484c16679633a54c"
 dependencies = [
  "libc",
+]
+
+[[package]]
+name = "yasna"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0de7bff972b4f2a06c85f6d8454b09df153af7e3a4ec2aac81db1b105b684ddb"
+dependencies = [
+ "bit-vec",
+ "num-bigint 0.2.6",
+]
+
+[[package]]
+name = "zeroize"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4756f7db3f7b5574938c3eb1c117038b8e07f95ee6718c0efad4ac21508f1efd"
+dependencies = [
+ "zeroize_derive",
+]
+
+[[package]]
+name = "zeroize_derive"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a2c1e130bebaeab2f23886bf9acbaca14b092408c452543c857f66399cd6dab1"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+ "synstructure",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -327,12 +327,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "bit-vec"
-version = "0.6.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "349f9b6a179ed607305526ca489b34ad0a41aed5f7980fa90eb03160b69598fb"
-
-[[package]]
 name = "bitflags"
 version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1114,6 +1108,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "getrandom"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c9495705279e7140bf035dde1f6e750c162df8b625267cd52cc44e0b156732c8"
+dependencies = [
+ "cfg-if 1.0.0",
+ "libc",
+ "wasi 0.10.0+wasi-snapshot-preview1",
+]
+
+[[package]]
 name = "ghash"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1319,7 +1324,7 @@ dependencies = [
  "httparse",
  "httpdate",
  "itoa",
- "pin-project 1.0.6",
+ "pin-project 1.0.7",
  "socket2",
  "tokio 0.2.24",
  "tower-service",
@@ -1890,6 +1895,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "num-bigint-dig"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4547ee5541c18742396ae2c895d0717d0f886d8823b8399cdaf7b07d63ad0480"
+dependencies = [
+ "autocfg 0.1.7",
+ "byteorder",
+ "lazy_static",
+ "libm",
+ "num-integer",
+ "num-iter",
+ "num-traits",
+ "rand 0.8.3",
+ "smallvec 1.6.1",
+ "zeroize",
+]
+
+[[package]]
 name = "num-integer"
 version = "0.1.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1917,6 +1940,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9a64b1ec5cda2586e284722486d802acf1f7dbdc623e2bfc57e65ca1cd099290"
 dependencies = [
  "autocfg 1.0.1",
+ "libm",
 ]
 
 [[package]]
@@ -2121,13 +2145,13 @@ dependencies = [
  "base64 0.12.3",
  "digest",
  "http 0.2.4",
- "num-bigint-dig",
+ "num-bigint-dig 0.6.1",
  "oid",
  "picky-asn1",
  "picky-asn1-der",
  "picky-asn1-x509",
  "rand 0.7.3",
- "rsa",
+ "rsa 0.3.0",
  "serde",
  "serde_json",
  "sha-1",
@@ -2165,7 +2189,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7c40870d0d056271c2976f7c1747b1df4332f979ab78634574ef5b534e6b0f0f"
 dependencies = [
  "base64 0.12.3",
- "num-bigint-dig",
+ "num-bigint-dig 0.6.1",
  "oid",
  "picky-asn1",
  "picky-asn1-der",
@@ -2183,11 +2207,11 @@ dependencies = [
 
 [[package]]
 name = "pin-project"
-version = "1.0.6"
+version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bc174859768806e91ae575187ada95c91a29e96a98dc5d2cd9a1fed039501ba6"
+checksum = "c7509cc106041c40a4518d2af7a61530e1eed0e6285296a3d8c5472806ccc4a4"
 dependencies = [
- "pin-project-internal 1.0.6",
+ "pin-project-internal 1.0.7",
 ]
 
 [[package]]
@@ -2203,9 +2227,9 @@ dependencies = [
 
 [[package]]
 name = "pin-project-internal"
-version = "1.0.6"
+version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a490329918e856ed1b083f244e3bfe2d8c4f336407e4ea9e1a9f479ff09049e5"
+checksum = "48c950132583b500556b1efd71d45b319029f2b71518d979fcc208e16b42426f"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2404,11 +2428,23 @@ version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6a6b1679d49b24bbfe0c803429aa1874472f50d9b363131f0e89fc356b544d03"
 dependencies = [
- "getrandom",
+ "getrandom 0.1.16",
  "libc",
  "rand_chacha 0.2.2",
  "rand_core 0.5.1",
  "rand_hc 0.2.0",
+]
+
+[[package]]
+name = "rand"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ef9e7e66b4468674bfcb0c81af8b7fa0bb154fa9f28eb840da5c447baeb8d7e"
+dependencies = [
+ "libc",
+ "rand_chacha 0.3.0",
+ "rand_core 0.6.2",
+ "rand_hc 0.3.0",
 ]
 
 [[package]]
@@ -2432,6 +2468,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "rand_chacha"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e12735cf05c9e10bf21534da50a147b924d555dc7a547c42e6bb2d5b6017ae0d"
+dependencies = [
+ "ppv-lite86",
+ "rand_core 0.6.2",
+]
+
+[[package]]
 name = "rand_core"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2452,7 +2498,16 @@ version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "90bde5296fc891b0cef12a6d03ddccc162ce7b2aff54160af9338f8d40df6d19"
 dependencies = [
- "getrandom",
+ "getrandom 0.1.16",
+]
+
+[[package]]
+name = "rand_core"
+version = "0.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "34cf66eb183df1c5876e2dcf6b13d57340741e8dc255b48e40a26de954d06ae7"
+dependencies = [
+ "getrandom 0.2.2",
 ]
 
 [[package]]
@@ -2471,6 +2526,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ca3129af7b92a17112d59ad498c6f81eaf463253766b90396d39ea7a39d6613c"
 dependencies = [
  "rand_core 0.5.1",
+]
+
+[[package]]
+name = "rand_hc"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3190ef7066a446f2e7f42e239d161e905420ccab01eb967c9eb27d21b2322a73"
+dependencies = [
+ "rand_core 0.6.2",
 ]
 
 [[package]]
@@ -2568,7 +2632,7 @@ version = "0.3.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "de0737333e7a9502c789a36d7c7fa6092a49895d4faa31ca5df163857ded2e9d"
 dependencies = [
- "getrandom",
+ "getrandom 0.1.16",
  "redox_syscall",
  "rust-argon2",
 ]
@@ -2681,9 +2745,9 @@ dependencies = [
 
 [[package]]
 name = "ring"
-version = "0.16.19"
+version = "0.16.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "024a1e66fea74c66c66624ee5622a7ff0e4b73a13b4f5c326ddb50c708944226"
+checksum = "3053cf52e236a3ed746dfc745aa9cacf1b791d846bdaf412f60a8d7d6e17c8fc"
 dependencies = [
  "cc",
  "libc",
@@ -2726,7 +2790,7 @@ dependencies = [
  "byteorder",
  "digest",
  "lazy_static",
- "num-bigint-dig",
+ "num-bigint-dig 0.6.1",
  "num-integer",
  "num-iter",
  "num-traits",
@@ -2740,42 +2804,23 @@ dependencies = [
 ]
 
 [[package]]
-name = "rsa-der"
-version = "0.2.1"
+name = "rsa"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1170c86c683547fa781a0e39e6e281ebaedd4515be8a806022984f427ea3d44d"
+checksum = "68ef841a26fc5d040ced0417c6c6a64ee851f42489df11cdf0218e545b6f8d28"
 dependencies = [
- "simple_asn1 0.4.1",
-]
-
-[[package]]
-name = "rsa-export"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a29a64b407c67f1f7a605538dc0975d40f5f1479fc1b04f7568c78120993f7f7"
-dependencies = [
- "num-bigint-dig",
+ "byteorder",
+ "digest",
+ "lazy_static",
+ "num-bigint-dig 0.7.0",
  "num-integer",
- "pem",
- "rsa",
- "simple_asn1 0.5.2",
-]
-
-[[package]]
-name = "rsa-pem"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3ee7d87640dab9972e4d05503aad4c30a107ca50912d10596d44f8555b7da4ce"
-dependencies = [
- "bit-vec",
- "log 0.4.11",
- "num-bigint 0.2.6",
- "num-bigint-dig",
+ "num-iter",
  "num-traits",
  "pem",
- "rsa",
- "thiserror",
- "yasna",
+ "rand 0.8.3",
+ "simple_asn1 0.5.2",
+ "subtle",
+ "zeroize",
 ]
 
 [[package]]
@@ -2876,17 +2921,14 @@ dependencies = [
  "picky",
  "picky-asn1-x509",
  "predicates",
- "rand 0.7.3",
+ "rand 0.8.3",
  "redis",
  "regex",
  "reqwest 0.10.10",
  "retry",
  "ring",
  "rouille",
- "rsa",
- "rsa-der",
- "rsa-export",
- "rsa-pem",
+ "rsa 0.4.0",
  "selenium-rs",
  "serde",
  "serde_derive",
@@ -3766,7 +3808,7 @@ version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "97d095ae15e245a057c8e8451bab9b3ee1e1f68e9ba2b4fbc18d0ac5237835f2"
 dependencies = [
- "pin-project 1.0.6",
+ "pin-project 1.0.7",
  "tracing",
 ]
 
@@ -4212,16 +4254,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "244c3741f4240ef46274860397c7c74e50eb23624996930e484c16679633a54c"
 dependencies = [
  "libc",
-]
-
-[[package]]
-name = "yasna"
-version = "0.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0de7bff972b4f2a06c85f6d8454b09df153af7e3a4ec2aac81db1b105b684ddb"
-dependencies = [
- "bit-vec",
- "num-bigint 0.2.6",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -52,10 +52,18 @@ linked-hash-map = "0.5"
 local-encoding = "0.2.0"
 log = "0.4"
 md-5 = { version = "0.9", optional = true }
+rsa = "0.3"
+# both are pkcs8 only
+rsa-pem = "0.2"
+rsa-der = "0.2"
+# exports pkcs#1
+rsa-export = "0.2"
+# Pin exact versions to make sure we use the exact same picky-asn1-x509 version
+picky = "=6.2.0"
+picky-asn1-x509 = "=0.5.0"
 memcached-rs = { version = "0.4" , optional = true }
 num_cpus = "1.0"
 number_prefix = "0.4"
-openssl = { version = "0.10", optional = true }
 percent-encoding = { version = "2", optional = true }
 rand = "0.7"
 redis = { version = "0.17", optional = true }
@@ -94,6 +102,9 @@ syslog = { version = "5", optional = true }
 void = { version = "1", optional = true }
 version-compare = { version = "0.0.11", optional = true }
 
+# test only
+openssl = { version = "0.10", optional = true }
+
 [dev-dependencies]
 assert_cmd = "1"
 cc = "1.0"
@@ -130,9 +141,11 @@ unstable = []
 # Enables distributed support in the sccache client
 dist-client = ["ar", "flate2", "hyper", "hyperx", "reqwest", "url", "sha2"]
 # Enables the sccache-dist binary
-dist-server = ["crossbeam-utils", "jsonwebtoken", "flate2", "hyperx", "libmount", "nix", "openssl", "reqwest", "rouille", "syslog", "void", "version-compare"]
+dist-server = ["chrono", "crossbeam-utils", "jsonwebtoken", "flate2", "hyperx", "libmount", "nix", "reqwest", "rouille", "sha2", "syslog", "void", "version-compare"]
 # Enables dist tests with external requirements
 dist-tests = ["dist-client", "dist-server"]
+# Run JWK token crypto against openssl ref impl
+vs_openssl = ["openssl", "dist-server"]
 
 [workspace]
 exclude = ["tests/test-crate"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -141,5 +141,10 @@ dist-tests = ["dist-client", "dist-server"]
 # Run JWK token crypto against openssl ref impl
 vs_openssl = ["openssl", "dist-server"]
 
+# Make sure to always optimize big integer calculations as this cuts down
+# certificate generation time by two orders of magnitude (down to ~0.1s)
+[profile.dev.package.num-bigint-dig]
+opt-level = 3
+
 [workspace]
 exclude = ["tests/test-crate"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -52,12 +52,7 @@ linked-hash-map = "0.5"
 local-encoding = "0.2.0"
 log = "0.4"
 md-5 = { version = "0.9", optional = true }
-rsa = "0.3"
-# both are pkcs8 only
-rsa-pem = "0.2"
-rsa-der = "0.2"
-# exports pkcs#1
-rsa-export = "0.2"
+rsa = "0.4"
 # Pin exact versions to make sure we use the exact same picky-asn1-x509 version
 picky = "=6.2.0"
 picky-asn1-x509 = "=0.5.0"
@@ -65,7 +60,7 @@ memcached-rs = { version = "0.4" , optional = true }
 num_cpus = "1.0"
 number_prefix = "0.4"
 percent-encoding = { version = "2", optional = true }
-rand = "0.7"
+rand = "0.8"
 redis = { version = "0.17", optional = true }
 regex = "1"
 reqwest = { version = "0.10", features = ["json", "blocking"], optional = true }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -53,9 +53,7 @@ local-encoding = "0.2.0"
 log = "0.4"
 md-5 = { version = "0.9", optional = true }
 rsa = "0.4"
-# Pin exact versions to make sure we use the exact same picky-asn1-x509 version
-picky = "=6.2.0"
-picky-asn1-x509 = "=0.5.0"
+picky = "6.2"
 memcached-rs = { version = "0.4" , optional = true }
 num_cpus = "1.0"
 number_prefix = "0.4"
@@ -102,6 +100,7 @@ openssl = { version = "0.10", optional = true }
 
 [dev-dependencies]
 assert_cmd = "1"
+assert_matches = "1.5"
 cc = "1.0"
 chrono = "0.4"
 itertools = "0.10"

--- a/README.md
+++ b/README.md
@@ -126,15 +126,16 @@ cargo build --release [--no-default-features --features=s3|redis|gcs|memcached|a
 
 By default, `sccache` builds with support for all storage backends, but individual backends may be disabled by resetting the list of features and enabling all the other backends. Refer the [Cargo Documentation](http://doc.crates.io/manifest.html#the-features-section) for details on how to select features with Cargo.
 
-### Building portable binaries
-
-When building with the `gcs` feature, `sccache` will depend on OpenSSL, which can be an annoyance if you want to distribute portable binaries. It is possible to statically link against OpenSSL using the `openssl/vendored` feature.
 
 #### Linux
+
+No native dependencies.
 
 Build with `cargo` and use `ldd` to check that the resulting binary does not depend on OpenSSL anymore.
 
 #### macOS
+
+No native dependencies.
 
 Build with `cargo` and use `otool -L` to check that the resulting binary does not depend on OpenSSL anymore.
 
@@ -150,8 +151,6 @@ rustflags = ["-Ctarget-feature=+crt-static"]
 ```
 
 Build with `cargo` and use `dumpbin /dependents` to check that the resulting binary does not depend on MSVC CRT DLLs anymore.
-
-When statically linking with OpenSSL, you will need Perl available in your `$PATH`.
 
 ---
 

--- a/src/bin/sccache-dist/token_check.rs
+++ b/src/bin/sccache-dist/token_check.rs
@@ -38,9 +38,7 @@ impl Jwk {
         let e = rsa::BigUint::from_bytes_be(&e);
         let pk = rsa::RSAPublicKey::new(n, e)?;
 
-        let pk = rsa_export::RsaKey::new(pk);
-        let pkcs1_der: Vec<u8> = pk
-            .as_pkcs1()
+        let pkcs1_der: Vec<u8> = rsa::PublicKeyEncoding::to_pkcs1(&pk)
             .map_err(|e| anyhow::anyhow!("{}", e))
             .context("Failed to create rsa pub key from (n, e)")?;
 

--- a/src/dist/http.rs
+++ b/src/dist/http.rs
@@ -301,7 +301,6 @@ mod server {
     use picky::x509::certificate::CertificateBuilder;
     use picky::x509::date::UTCDate;
     use picky::x509::extension::ExtendedKeyUsage;
-    use picky::x509::extension::KeyUsage;
     use picky::x509::key_id_gen_method::KeyIdGenMethod;
     use picky::x509::name::{DirectoryName, GeneralNames};
 
@@ -359,7 +358,6 @@ mod server {
         let cert = CertificateBuilder::new()
             .ca(false)
             .validity(start, end)
-            .key_usage(KeyUsage::new(1))
             .subject(subject_name, pk)
             .subject_alt_name(subject_alt_name)
             .serial_number(vec![1]) // cannot be 0 according to picky internal notes

--- a/src/dist/http.rs
+++ b/src/dist/http.rs
@@ -1431,6 +1431,15 @@ mod tests {
         Ok((cert_digest, cert_pem, privkey_pem))
     }
 
+    macro_rules! timeit {
+        ($work:expr) => {{
+            let start = ::std::time::Instant::now();
+            let x = { $work };
+            eprintln!("took: {:#?}", start.elapsed());
+            x
+        }};
+    }
+
     #[test]
     fn create_cert_and_sk() {
         let addr = "242.11.9.38:29114".parse().unwrap();
@@ -1466,8 +1475,10 @@ mod tests {
             picky::x509::Cert::from_pem(&pem).expect("Cert from PEM must be ok. Q.E.D.")
         };
 
-        let generated: Triple = create_https_cert_and_privkey(addr).unwrap().into();
-        let expected: Triple = legacy_create_https_cert_and_privkey(addr).unwrap().into();
+        let generated: Triple = timeit!(create_https_cert_and_privkey(addr)).unwrap().into();
+        let expected: Triple = timeit!(legacy_create_https_cert_and_privkey(addr))
+            .unwrap()
+            .into();
         // cert
         {
             let expected_cert = convert("exp", &expected.cert_pem);

--- a/src/dist/http.rs
+++ b/src/dist/http.rs
@@ -301,7 +301,6 @@ mod server {
     use picky::x509::certificate::CertificateBuilder;
     use picky::x509::date::UTCDate;
     use picky::x509::extension::ExtendedKeyUsage;
-    use picky::x509::key_id_gen_method::KeyIdGenMethod;
     use picky::x509::name::{DirectoryName, GeneralNames};
 
     use picky::{hash::HashAlgorithm, signature::SignatureAlgorithm};
@@ -362,9 +361,6 @@ mod server {
             .subject_alt_name(subject_alt_name)
             .serial_number(vec![1]) // cannot be 0 according to picky internal notes
             .signature_hash_type(SignatureAlgorithm::RsaPkcs1v15(HashAlgorithm::SHA1))
-            .key_id_gen_method(KeyIdGenMethod::SPKValueHashedLeftmost160(
-                HashAlgorithm::SHA2_256,
-            ))
             .extended_key_usage(extended_key_usage)
             .self_signed(issuer_name, &sk)
             .build()?;

--- a/src/dist/http.rs
+++ b/src/dist/http.rs
@@ -306,7 +306,6 @@ mod server {
     use picky::x509::name::{DirectoryName, GeneralNames};
     use picky::x509::Extensions;
     use picky::{hash::HashAlgorithm, signature::SignatureAlgorithm};
-    use rsa_pem::KeyExt;
     use sha2::Digest;
     use std::net::{IpAddr, SocketAddr};
     use std::ops::DerefMut;
@@ -318,8 +317,8 @@ mod server {
         let bits = 2048;
         let rsa_key = rsa::RSAPrivateKey::new(&mut rng, bits)?;
 
-        let sk_pkcs8 = <rsa::RSAPrivateKey>::to_pem_pkcs8(&rsa_key)?;
-        let pk_pkcs8 = <rsa::RSAPublicKey>::to_pem_pkcs8(&rsa_key)?;
+        let sk_pkcs8 = rsa::PrivateKeyPemEncoding::to_pem_pkcs8(&rsa_key)?;
+        let pk_pkcs8 = rsa::PublicKeyPemEncoding::to_pem_pkcs8(&*rsa_key)?;
 
         // convert to picky
         let sk = PrivateKey::from_pem_str(sk_pkcs8.as_str())?;


### PR DESCRIPTION
Last change split from https://github.com/paritytech/sccache/tree/legacy-rebased. This also includes an extra commit which upgrades `rsa` to 0.4 (see commit for rationale; we can skip that commit for now).

Ideally this is something that we'd like to upstream (see https://github.com/mozilla/sccache/pull/879 for previous attempt).