### PR TITLE
ci: Perform nightly CI/CD runs to catch possible breakage

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,5 +1,12 @@
 name: ci
-on: [push, pull_request]
+on:
+  pull_request:
+  push:
+  # Run periodic nightly checks to catch unrelated possible breakages
+  # in the meantime (e.g. some not pinned Docker image being updated or
+  # a change in the CI environment)
+  schedule:
+    - cron: '0 0 * * *'
 jobs:
   lint:
     name: ${{ matrix.component }} ${{ matrix.os }}


### PR DESCRIPTION
This helps catching issues unrelated to PRs (which are the most frequent
reason to perform CI runs until now) only popping up when these are
opened. Instead, perform sanity nightly runs to catch the breakage beforehand.
A nice side-effect is that this also builds nightly binaries as part of
the workflows.

Refs: https://github.com/paritytech/sccache/pull/74 https://github.com/paritytech/sccache/pull/67