### PR TITLE
CI: fix publishing

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -54,6 +54,14 @@ workflow:
     - if: $CI_COMMIT_REF_NAME =~ /^[0-9]+$/                         # PRs
     - if: $CI_COMMIT_REF_NAME =~ /^v[0-9]+\.[0-9]+.*$/              # i.e. v1.0, v2.1rc1
 
+.publish-refs:                     &publish-refs
+  rules:
+    - if: $CI_PIPELINE_SOURCE == "web"
+    - if: $CI_PIPELINE_SOURCE == "schedule"
+    - if: $CI_COMMIT_REF_NAME == "master"
+    - if: $CI_COMMIT_REF_NAME == "tags"
+    - if: $CI_COMMIT_REF_NAME =~ /^v[0-9]+\.[0-9]+.*$/              # i.e. v1.0, v2.1rc1
+
 .collect-artifacts:                &collect-artifacts
   artifacts:
     name:                          "${CI_JOB_NAME}_${CI_COMMIT_REF_NAME}"
@@ -143,6 +151,7 @@ build:
 
 publish-sccache-dist:
   stage:                           publish
+  <<:                              *publish-refs
   <<:                              *build-push-docker-image
   needs:
     - job:                         build


### PR DESCRIPTION
`paritytech` dockerhub creds are protected to use on protected branches only, thus this job should only be executed only on master branch. Or in some rare cases, you can return the line
```
     - if: $CI_COMMIT_REF_NAME =~ /^[0-9]+$/                         # PRs
 ````
and protect the branch you want to experiment on. Also won't hurt to add an experimental tag to the image to not to mess production.