### PR TITLE
CI: fix publishing again

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -122,7 +122,6 @@ build:
 
 
 .build-push-docker-image:          &build-push-docker-image
-  <<:                              *build-refs
   <<:                              *kubernetes-env
   image:                           quay.io/buildah/stable
   variables:                       &docker-build-vars


### PR DESCRIPTION
overlooked that the job was inheriting some `rules` from the anchor :sweat_smile: 