### PR TITLE
Adds SUBSTRATE_ env variables to hash

### DIFF
--- a/src/compiler/rust.rs
+++ b/src/compiler/rust.rs
@@ -1378,7 +1378,9 @@ where
         env_vars.sort();
         for &(ref var, ref val) in env_vars.iter() {
             // CARGO_MAKEFLAGS will have jobserver info which is extremely non-cacheable.
-            if var.starts_with("CARGO_") && var != "CARGO_MAKEFLAGS" {
+            if (var.starts_with("CARGO_") && var != "CARGO_MAKEFLAGS")
+                || var.starts_with("SUBSTRATE_")
+            {
                 var.hash(&mut HashToDigest { digest: &mut m });
                 m.update(b"=");
                 val.hash(&mut HashToDigest { digest: &mut m });


### PR DESCRIPTION
This allow to be more consistent when building substrate node, as the substrate uses the environment variable `SUBSTRATE_CLI_IMPL_VERSION` to propagate the version:
```
	println!("cargo:rustc-env=SUBSTRATE_CLI_IMPL_VERSION={}", get_version(&commit))
```

This environment variable was ignored by SCCache preventing the binary to display the right version